### PR TITLE
docs: update documentation for truenas-mcp

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1,0 +1,116 @@
+# truenas-mcp Overview
+
+## Purpose
+
+truenas-mcp is an MCP (Model Context Protocol) server that exposes TrueNAS SCALE management capabilities to AI assistants. It connects to a TrueNAS SCALE instance (Goldeye/25.10+) via its WebSocket JSON-RPC API and presents storage, sharing, system, and app management as MCP tools over stdio transport.
+
+## Architecture
+
+```
+main.go                  Entry point — uses Charm fang CLI framework
+├── cmd/
+│   ├── root.go          Root cobra command (truenas-mcp)
+│   └── serve.go         `serve` subcommand — connects to TrueNAS, starts MCP server
+├── truenas/
+│   └── client.go        WebSocket JSON-RPC client wrapper
+└── server/
+    ├── server.go         MCP server setup and tool registration
+    ├── tools_system.go   System/disk/network query tools + shared helpers
+    ├── tools_pool.go     ZFS pool tools
+    ├── tools_dataset.go  Dataset list/get/create/delete tools
+    ├── tools_snapshot.go Snapshot list/get/create/delete tools
+    ├── tools_share.go    SMB and NFS share tools
+    ├── tools_alert.go    Alert list/dismiss tools
+    └── tools_app.go      App list/get/start/stop/restart tools
+```
+
+### Data Flow
+
+1. CLI parses flags/env vars and calls `truenas.Connect(host, apiKey)` to open a WebSocket
+2. `server.New(client, readOnly)` creates the MCP server and registers tools
+3. `server.Run()` starts the MCP server on stdio, blocking until disconnect
+4. Each tool handler calls `client.Call(method, params...)` which:
+   - Sends a JSON-RPC call over WebSocket with a 30-second timeout
+   - Parses the response envelope, extracting `result` or `error`
+   - Returns `json.RawMessage` which the tool handler pretty-prints as the MCP response
+
+### Key Packages
+
+| Package | Role |
+|---------|------|
+| `cmd` | CLI wiring via Cobra + Charm fang. Handles flag/env parsing. |
+| `truenas` | Thin wrapper around `github.com/truenas/api_client_golang`. Provides `Connect`, `Call`, `Close`. |
+| `server` | MCP server construction and all tool definitions. Each `tools_*.go` file covers one domain. |
+
+## Key Patterns
+
+### Tool Registration Pattern
+
+Tools are split into read and write registration functions per domain:
+- `register<Domain>Tools` or `register<Domain>ReadTools` — always registered
+- `register<Domain>WriteTools` — only registered when `readOnly` is false
+
+Each tool is defined inline with `s.AddTool(&mcp.Tool{...}, handlerFunc)`. The handler extracts arguments from `req.Params.Arguments`, calls the TrueNAS API, and returns pretty-printed JSON.
+
+### Read-Only Mode
+
+When `--read-only` is set (or `TRUENAS_READ_ONLY` env var is non-empty), mutating tools (create, delete, start, stop, restart, dismiss) are never registered. AI clients cannot see or invoke them.
+
+### Schema Helpers
+
+`tools_system.go` defines shared helpers used across all tool files:
+- `schema()`, `noArgs()` — build MCP input schema objects
+- `stringProp()`, `numberProp()`, `boolProp()`, `arrayProp()` — property builders
+- `args()` — extracts argument map from request
+- `jsonResult()` — wraps raw JSON as pretty-printed MCP text content
+
+### TrueNAS API Mapping
+
+Tools map directly to TrueNAS JSON-RPC methods. The naming convention is:
+- Tool: `truenas_<domain>_<action>` (e.g., `truenas_dataset_create`)
+- API method: `<service>.<action>` (e.g., `pool.dataset.create`)
+
+Query tools typically pass filter arrays like `[["field", "=", value]]` to the API.
+
+### Error Handling
+
+The `Client.Call` method checks for errors at two levels:
+1. WebSocket/transport errors from the underlying client
+2. JSON-RPC level errors in the response envelope (`error` field)
+
+Tool handlers wrap API errors with context (e.g., `fmt.Errorf("pool.query: %w", err)`).
+
+## Configuration
+
+| Source | Variable/Flag | Description |
+|--------|--------------|-------------|
+| Flag | `--host` | TrueNAS host address (e.g., `truenas.local`) |
+| Env | `TRUENAS_HOST` | Same as `--host` |
+| Flag | `--api-key` | TrueNAS API key |
+| Env | `TRUENAS_API_KEY` | Same as `--api-key` |
+| Flag | `--read-only` | Restrict to read-only tools |
+| Env | `TRUENAS_READ_ONLY` | Any non-empty value enables read-only mode |
+
+Flags take precedence over defaults; env vars are used as default values for flags (via `envOrDefault` in `cmd/serve.go`).
+
+### Connection Details
+
+- WebSocket URL: `wss://<host>/api/current`
+- SSL verification is disabled (self-signed certs common on NAS devices)
+- Authentication via API key (not username/password)
+- API call timeout: 30 seconds
+
+## MCP Tools Reference
+
+See [tools.md](tools.md) for the complete tool catalog with parameters.
+
+## Build & Run
+
+```bash
+make              # fmt + vet + build
+make run          # build and run `serve`
+make test         # run tests with race detector
+make lint         # golangci-lint
+```
+
+Binary name: `truenas-mcp`. Version: `0.1.0`.

--- a/yeti/tools.md
+++ b/yeti/tools.md
@@ -1,0 +1,174 @@
+# MCP Tools Reference
+
+Complete catalog of MCP tools exposed by truenas-mcp. Tools marked with **[write]** are excluded in `--read-only` mode.
+
+## System Tools (`tools_system.go`)
+
+### `truenas_system_info`
+Get system hostname, version, uptime, and platform.
+- Parameters: none
+- API: `system.info`
+
+### `truenas_disk_list`
+List all physical disks with name, size, model, serial, and health status.
+- Parameters: none
+- API: `disk.query`
+
+### `truenas_network_list`
+List network interfaces with IP addresses and link status.
+- Parameters: none
+- API: `interface.query`
+
+## Pool Tools (`tools_pool.go`)
+
+### `truenas_pool_list`
+List all ZFS pools with name, status, size, and health.
+- Parameters: none
+- API: `pool.query`
+
+### `truenas_pool_get`
+Get detailed pool info including topology (vdevs, disks).
+- Parameters:
+  - `name` (string, required) — pool name
+- API: `pool.query` with filter `[["name", "=", name]]`
+
+## Dataset Tools (`tools_dataset.go`)
+
+### `truenas_dataset_list`
+List datasets with usage, mountpoint, and compression info.
+- Parameters:
+  - `pool` (string, optional) — filter by pool name
+- API: `pool.dataset.query`
+
+### `truenas_dataset_get`
+Get full properties for a specific dataset.
+- Parameters:
+  - `path` (string, required) — full dataset path (e.g., `tank/data`)
+- API: `pool.dataset.query` with filter `[["id", "=", path]]`
+
+### `truenas_dataset_create` **[write]**
+Create a new ZFS dataset.
+- Parameters:
+  - `name` (string, required) — full dataset path (e.g., `tank/newdata`)
+  - `comments` (string, optional) — description
+  - `compression` (string, optional) — algorithm (lz4, zstd, off)
+- API: `pool.dataset.create`
+
+### `truenas_dataset_delete` **[write]**
+Delete a ZFS dataset. Destructive and irreversible.
+- Parameters:
+  - `path` (string, required) — full dataset path
+- API: `pool.dataset.delete`
+
+## Snapshot Tools (`tools_snapshot.go`)
+
+### `truenas_snapshot_list`
+List snapshots for a dataset with name, creation time, and referenced size.
+- Parameters:
+  - `dataset` (string, required) — dataset path
+- API: `zfs.snapshot.query` with filter `[["dataset", "=", dataset]]`
+
+### `truenas_snapshot_get`
+Get full details for a specific snapshot.
+- Parameters:
+  - `name` (string, required) — full snapshot name (e.g., `tank/data@snap1`)
+- API: `zfs.snapshot.query` with filter `[["id", "=", name]]`
+
+### `truenas_snapshot_create` **[write]**
+Create a ZFS snapshot. Auto-generates a timestamp name (`auto-YYYYMMDD-HHMMSS`) if name is omitted.
+- Parameters:
+  - `dataset` (string, required) — dataset path
+  - `name` (string, optional) — snapshot name
+- API: `zfs.snapshot.create`
+
+### `truenas_snapshot_delete` **[write]**
+Delete a ZFS snapshot. Destructive.
+- Parameters:
+  - `name` (string, required) — full snapshot name (e.g., `tank/data@snap1`)
+- API: `zfs.snapshot.delete`
+
+## Share Tools (`tools_share.go`)
+
+### `truenas_smb_list`
+List all SMB shares with name, path, and enabled status.
+- Parameters: none
+- API: `sharing.smb.query`
+
+### `truenas_smb_create` **[write]**
+Create an SMB share.
+- Parameters:
+  - `name` (string, required) — share name
+  - `path` (string, required) — filesystem path (e.g., `/mnt/tank/data`)
+  - `comment` (string, optional) — description
+  - `guest_ok` (boolean, optional) — allow guest access (default false)
+- API: `sharing.smb.create`
+
+### `truenas_smb_delete` **[write]**
+Delete an SMB share.
+- Parameters:
+  - `id` (number, required) — share ID
+- API: `sharing.smb.delete`
+
+### `truenas_nfs_list`
+List all NFS exports with path, networks, and enabled status.
+- Parameters: none
+- API: `sharing.nfs.query`
+
+### `truenas_nfs_create` **[write]**
+Create an NFS export.
+- Parameters:
+  - `path` (string, required) — filesystem path
+  - `networks` (string[], optional) — allowed networks (e.g., `192.168.1.0/24`)
+  - `hosts` (string[], optional) — allowed hosts
+- API: `sharing.nfs.create`
+
+### `truenas_nfs_delete` **[write]**
+Delete an NFS export.
+- Parameters:
+  - `id` (number, required) — export ID
+- API: `sharing.nfs.delete`
+
+## Alert Tools (`tools_alert.go`)
+
+### `truenas_alert_list`
+List active alerts with level, message, datetime, and dismissed status.
+- Parameters:
+  - `level` (string, optional) — filter: `INFO`, `WARNING`, `CRITICAL`, or empty for all
+- API: `alert.list`
+
+### `truenas_alert_dismiss` **[write]**
+Dismiss an alert.
+- Parameters:
+  - `id` (string, required) — alert ID
+- API: `alert.dismiss`
+
+## App Tools (`tools_app.go`)
+
+### `truenas_app_list`
+List installed apps with name, version, status, and update availability.
+- Parameters: none
+- API: `app.query`
+
+### `truenas_app_get`
+Get detailed info for a specific app.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.query` with filter `[["name", "=", name]]`
+
+### `truenas_app_start` **[write]**
+Start a stopped app.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.start`
+
+### `truenas_app_stop` **[write]**
+Stop a running app.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.stop`
+
+### `truenas_app_restart` **[write]**
+Restart an app.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.restart`


### PR DESCRIPTION
## Summary

Add comprehensive project documentation covering the architecture, configuration, and MCP tool catalog for truenas-mcp. These docs provide a quick-start reference for contributors and AI assistants working with the codebase.

## Changes

- Added `yeti/OVERVIEW.md` — project purpose, architecture diagram, data flow, key patterns (tool registration, read-only mode, schema helpers, error handling), configuration reference, and build instructions
- Added `yeti/tools.md` — complete MCP tools catalog (27 tools across 7 domains) with parameters, API method mappings, and read-only/write annotations