### PR TITLE
refactor: Consolidate duplicated version string into a single constant

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"truenas-mcp/version"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -9,7 +10,7 @@ func NewRootCmd() *cobra.Command {
 		Use:     "truenas-mcp",
 		Short:   "MCP server for TrueNAS SCALE",
 		Long:    "An MCP (Model Context Protocol) server that exposes TrueNAS SCALE management capabilities to AI assistants.",
-		Version: "0.1.0",
+		Version: version.Version,
 	}
 
 	cmd.AddCommand(NewServeCmd())

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/fang/v2"
 	"truenas-mcp/cmd"
+	"truenas-mcp/version"
 )
 
 func main() {
@@ -14,7 +15,7 @@ func main() {
 	if err := fang.Execute(
 		context.Background(),
 		root,
-		fang.WithVersion("0.1.0"),
+		fang.WithVersion(version.Version),
 		fang.WithNotifySignal(os.Interrupt),
 	); err != nil {
 		os.Exit(1)

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"truenas-mcp/truenas"
+	"truenas-mcp/version"
 )
 
 // New creates an MCP server with TrueNAS tools registered.
@@ -12,7 +13,7 @@ import (
 func New(client *truenas.Client, readOnly bool) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    "truenas-mcp",
-		Version: "0.1.0",
+		Version: version.Version,
 	}, nil)
 
 	// Read-only tools — always registered

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the single source of truth for the application version.
+const Version = "0.1.0"


### PR DESCRIPTION
The version "0.1.0" is hardcoded in three separate places:
- `main.go:17` (`fang.WithVersion("0.1.0")`)
- `cmd/root.go:12` (`Version: "0.1.0"`)
- `server/server.go:15` (`Version: "0.1.0"`)

If any one is updated without the others, the reported version will be inconsistent depending on whether the user runs `--version`, or the MCP client reads the server implementation info.

Define a single `const Version = "0.1.0"` (e.g. in a top-level `version.go` or in the `cmd` package) and reference it from all three locations. This eliminates the risk of version drift.

---
*Automated improvement by yeti improvement-identifier*