### PR TITLE
refactor: Remove unused Client.API() method

### DIFF
--- a/truenas/client.go
+++ b/truenas/client.go
@@ -37,11 +37,6 @@ func (c *Client) Close() {
 	}
 }
 
-// API returns the underlying TrueNAS API client for making calls.
-func (c *Client) API() *truenas_api.Client {
-	return c.api
-}
-
 // Call invokes a TrueNAS JSON-RPC method and returns the result as raw JSON.
 // It handles the envelope parsing and error extraction.
 func (c *Client) Call(method string, params ...interface{}) (json.RawMessage, error) {


### PR DESCRIPTION
The `API()` method on `truenas.Client` (`truenas/client.go:41-43`) is never called anywhere in the codebase. It exposes the internal `*truenas_api.Client`, which breaks encapsulation — all callers use `Client.Call()` instead. Remove this dead code to keep the public API surface minimal.

---
*Automated improvement by yeti improvement-identifier*