### PR TITLE
fix: resolve #4 — add tests where possible

### DIFF
--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnvOrDefault_Set(t *testing.T) {
+	t.Setenv("TEST_ENVORD_KEY", "myval")
+	got := envOrDefault("TEST_ENVORD_KEY", "fallback")
+	if got != "myval" {
+		t.Errorf("envOrDefault = %q, want %q", got, "myval")
+	}
+}
+
+func TestEnvOrDefault_Unset(t *testing.T) {
+	t.Setenv("TEST_ENVORD_KEY", "")
+	got := envOrDefault("TEST_ENVORD_KEY", "fallback")
+	if got != "fallback" {
+		t.Errorf("envOrDefault = %q, want %q", got, "fallback")
+	}
+}
+
+func TestEnvOrDefault_Empty(t *testing.T) {
+	t.Setenv("TEST_ENVORD_KEY", "")
+	got := envOrDefault("TEST_ENVORD_KEY", "default")
+	if got != "default" {
+		t.Errorf("envOrDefault with empty string = %q, want %q", got, "default")
+	}
+}
+
+func TestServeCmd_MissingHost(t *testing.T) {
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+	t.Setenv("TRUENAS_READ_ONLY", "")
+
+	cmd := NewServeCmd()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing host")
+	}
+	if !strings.Contains(err.Error(), "host is required") {
+		t.Errorf("error = %q, want it to contain 'host is required'", err.Error())
+	}
+}
+
+func TestServeCmd_MissingAPIKey(t *testing.T) {
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+	t.Setenv("TRUENAS_READ_ONLY", "")
+
+	cmd := NewServeCmd()
+	cmd.SetArgs([]string{"--host", "fake.local"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !strings.Contains(err.Error(), "API key is required") {
+		t.Errorf("error = %q, want it to contain 'API key is required'", err.Error())
+	}
+}
+
+func TestServeCmd_ReadOnlyEnvQuirk(t *testing.T) {
+	// Any non-empty value of TRUENAS_READ_ONLY enables read-only mode,
+	// including "false" or "0".
+	t.Setenv("TRUENAS_READ_ONLY", "false")
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+
+	cmd := NewServeCmd()
+	readOnly, err := cmd.Flags().GetBool("read-only")
+	if err != nil {
+		t.Fatalf("getting read-only flag: %v", err)
+	}
+	if !readOnly {
+		t.Error("TRUENAS_READ_ONLY='false' should still enable read-only mode (any non-empty value)")
+	}
+}

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestSchema(t *testing.T) {
+	s := schema(map[string]any{
+		"name": stringProp("a name"),
+	}, "name")
+
+	if s["type"] != "object" {
+		t.Errorf("type = %v, want object", s["type"])
+	}
+	props, ok := s["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties is not map[string]any")
+	}
+	if _, ok := props["name"]; !ok {
+		t.Error("properties missing 'name'")
+	}
+	req, ok := s["required"].([]string)
+	if !ok {
+		t.Fatal("required is not []string")
+	}
+	if len(req) != 1 || req[0] != "name" {
+		t.Errorf("required = %v, want [name]", req)
+	}
+}
+
+func TestSchema_NoRequired(t *testing.T) {
+	s := schema(map[string]any{
+		"name": stringProp("a name"),
+	})
+
+	if _, ok := s["required"]; ok {
+		t.Error("expected no 'required' key when no required args given")
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	s := noArgs()
+	if s["type"] != "object" {
+		t.Errorf("type = %v, want object", s["type"])
+	}
+	props, ok := s["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties is not map[string]any")
+	}
+	if len(props) != 0 {
+		t.Errorf("properties has %d entries, want 0", len(props))
+	}
+}
+
+func TestStringProp(t *testing.T) {
+	p := stringProp("a description")
+	if p["type"] != "string" {
+		t.Errorf("type = %v, want string", p["type"])
+	}
+	if p["description"] != "a description" {
+		t.Errorf("description = %v, want 'a description'", p["description"])
+	}
+}
+
+func TestNumberProp(t *testing.T) {
+	p := numberProp("a number")
+	if p["type"] != "number" {
+		t.Errorf("type = %v, want number", p["type"])
+	}
+}
+
+func TestBoolProp(t *testing.T) {
+	p := boolProp("a bool")
+	if p["type"] != "boolean" {
+		t.Errorf("type = %v, want boolean", p["type"])
+	}
+}
+
+func TestArrayProp(t *testing.T) {
+	p := arrayProp("a list")
+	if p["type"] != "array" {
+		t.Errorf("type = %v, want array", p["type"])
+	}
+	items, ok := p["items"].(map[string]any)
+	if !ok {
+		t.Fatal("items is not map[string]any")
+	}
+	if items["type"] != "string" {
+		t.Errorf("items.type = %v, want string", items["type"])
+	}
+}
+
+func TestArgs_Valid(t *testing.T) {
+	req := &mcp.CallToolRequest{}
+	req.Params = &mcp.CallToolParamsRaw{
+		Arguments: json.RawMessage(`{"name":"tank","size":42}`),
+	}
+
+	a := args(req)
+	if a["name"] != "tank" {
+		t.Errorf("name = %v, want tank", a["name"])
+	}
+	if a["size"] != 42.0 {
+		t.Errorf("size = %v, want 42", a["size"])
+	}
+}
+
+func TestArgs_NilArguments(t *testing.T) {
+	req := &mcp.CallToolRequest{}
+	req.Params = &mcp.CallToolParamsRaw{}
+	a := args(req)
+	if a == nil {
+		t.Fatal("args returned nil, want empty map")
+	}
+	if len(a) != 0 {
+		t.Errorf("args returned %d entries, want 0", len(a))
+	}
+}
+
+func TestArgs_MalformedJSON(t *testing.T) {
+	req := &mcp.CallToolRequest{}
+	req.Params = &mcp.CallToolParamsRaw{
+		Arguments: json.RawMessage(`{invalid`),
+	}
+
+	a := args(req)
+	if a == nil {
+		t.Fatal("args returned nil, want empty map")
+	}
+	if len(a) != 0 {
+		t.Errorf("args returned %d entries, want 0", len(a))
+	}
+}
+
+func TestJsonResult(t *testing.T) {
+	raw := json.RawMessage(`{"hostname":"nas","version":"24.04"}`)
+	result, err := jsonResult(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if text == "" {
+		t.Error("result text is empty")
+	}
+	// Verify it's pretty-printed (contains newlines)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["hostname"] != "nas" {
+		t.Errorf("hostname = %v, want nas", parsed["hostname"])
+	}
+}
+
+func TestJsonResult_InvalidJSON(t *testing.T) {
+	raw := json.RawMessage(`{invalid`)
+	_, err := jsonResult(raw)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}

--- a/server/mock_test.go
+++ b/server/mock_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"truenas-mcp/truenas"
+)
+
+// mockCaller implements truenas.Caller for testing.
+type mockCaller struct {
+	CallFunc func(method string, params ...interface{}) (json.RawMessage, error)
+}
+
+var _ truenas.Caller = (*mockCaller)(nil)
+
+func (m *mockCaller) Call(method string, params ...interface{}) (json.RawMessage, error) {
+	return m.CallFunc(method, params...)
+}
+
+// callTool creates a server with the given caller, connects an in-memory client,
+// and invokes the named tool with the provided arguments.
+func callTool(t *testing.T, caller truenas.Caller, readOnly bool, toolName string, args map[string]any) (*mcp.CallToolResult, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	s := New(caller, readOnly)
+	ct, st := mcp.NewInMemoryTransports()
+
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer ss.Close()
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer cs.Close()
+
+	return cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: args,
+	})
+}
+
+// resultText extracts the text string from the first TextContent in a CallToolResult.
+func resultText(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	if r == nil {
+		t.Fatal("result is nil")
+	}
+	if len(r.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content is %T, want *mcp.TextContent", r.Content[0])
+	}
+	return tc.Text
+}

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,7 @@ import (
 
 // New creates an MCP server with TrueNAS tools registered.
 // When readOnly is true, only read-only tools (list, get, inspect) are registered.
-func New(client *truenas.Client, readOnly bool) *mcp.Server {
+func New(client truenas.Caller, readOnly bool) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    "truenas-mcp",
 		Version: version.Version,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNew_ReadOnly(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{}`), nil
+		},
+	}
+	s := New(mock, true)
+	if s == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestNew_ReadWrite(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{}`), nil
+		},
+	}
+	s := New(mock, false)
+	if s == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestNew_ReadOnly_NoWriteTools(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{}`), nil
+		},
+	}
+	// Calling a write tool on a read-only server should fail
+	_, err := callTool(t, mock, true, "truenas_dataset_create", map[string]any{"name": "tank/test"})
+	if err == nil {
+		t.Error("expected error calling write tool on read-only server, got nil")
+	}
+}

--- a/server/tools_alert.go
+++ b/server/tools_alert.go
@@ -8,7 +8,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerAlertReadTools(s *mcp.Server, client *truenas.Client) {
+func registerAlertReadTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_alert_list",
 		Description: "List active alerts with level (info/warning/critical), message, datetime, and dismissed status. Optionally filter by level.",
@@ -30,7 +30,7 @@ func registerAlertReadTools(s *mcp.Server, client *truenas.Client) {
 
 }
 
-func registerAlertWriteTools(s *mcp.Server, client *truenas.Client) {
+func registerAlertWriteTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_alert_dismiss",
 		Description: "Dismiss an alert by ID.",

--- a/server/tools_alert_test.go
+++ b/server/tools_alert_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAlertList_NoFilter(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "alert.list" {
+				t.Errorf("method = %q, want alert.list", method)
+			}
+			if len(params) != 0 {
+				t.Errorf("expected no params, got %d", len(params))
+			}
+			return json.RawMessage(`[{"id":"abc","level":"INFO"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_alert_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAlertList_WithLevel(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if len(params) == 0 {
+				t.Fatal("expected filter params")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if filter[0][0] != "level" || filter[0][2] != "CRITICAL" {
+				t.Errorf("filter = %v, want [[level = CRITICAL]]", filter)
+			}
+			return json.RawMessage(`[{"id":"abc","level":"CRITICAL"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_alert_list", map[string]any{"level": "CRITICAL"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAlertDismiss_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "alert.dismiss" {
+				t.Errorf("method = %q, want alert.dismiss", method)
+			}
+			if len(params) == 0 || params[0] != "alert-123" {
+				t.Errorf("params = %v, want [alert-123]", params)
+			}
+			return json.RawMessage(`true`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_alert_dismiss", map[string]any{"id": "alert-123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAlertDismiss_MissingID(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_alert_dismiss", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing id")
+	}
+}

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -8,7 +8,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerAppReadTools(s *mcp.Server, client *truenas.Client) {
+func registerAppReadTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_app_list",
 		Description: "List all installed apps with name, version, status (running/stopped), and update availability.",
@@ -42,7 +42,7 @@ func registerAppReadTools(s *mcp.Server, client *truenas.Client) {
 
 }
 
-func registerAppWriteTools(s *mcp.Server, client *truenas.Client) {
+func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_app_start",
 		Description: "Start a stopped app by name.",

--- a/server/tools_app_test.go
+++ b/server/tools_app_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAppList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.query" {
+				t.Errorf("method = %q, want app.query", method)
+			}
+			if len(params) != 0 {
+				t.Errorf("expected no params, got %d", len(params))
+			}
+			return json.RawMessage(`[{"name":"plex","status":"running"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAppGet_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.query" {
+				t.Errorf("method = %q, want app.query", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected filter params")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if filter[0][0] != "name" || filter[0][2] != "plex" {
+				t.Errorf("filter = %v, want [[name = plex]]", filter)
+			}
+			return json.RawMessage(`[{"name":"plex","status":"running"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_get", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAppGet_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_get", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppStart_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.start" {
+				t.Errorf("method = %q, want app.start", method)
+			}
+			if len(params) == 0 || params[0] != "plex" {
+				t.Errorf("params = %v, want [plex]", params)
+			}
+			return json.RawMessage(`null`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_start", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAppStart_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_start", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppStop_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.stop" {
+				t.Errorf("method = %q, want app.stop", method)
+			}
+			if len(params) == 0 || params[0] != "plex" {
+				t.Errorf("params = %v, want [plex]", params)
+			}
+			return json.RawMessage(`null`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_stop", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAppStop_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_stop", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppRestart_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.restart" {
+				t.Errorf("method = %q, want app.restart", method)
+			}
+			if len(params) == 0 || params[0] != "plex" {
+				t.Errorf("params = %v, want [plex]", params)
+			}
+			return json.RawMessage(`null`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_restart", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestAppRestart_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_restart", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}

--- a/server/tools_dataset.go
+++ b/server/tools_dataset.go
@@ -8,7 +8,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerDatasetReadTools(s *mcp.Server, client *truenas.Client) {
+func registerDatasetReadTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_dataset_list",
 		Description: "List datasets with name, used space, available space, mountpoint, and compression. Optionally filter by pool.",
@@ -49,7 +49,7 @@ func registerDatasetReadTools(s *mcp.Server, client *truenas.Client) {
 
 }
 
-func registerDatasetWriteTools(s *mcp.Server, client *truenas.Client) {
+func registerDatasetWriteTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_dataset_create",
 		Description: "Create a new ZFS dataset. Requires the full path (e.g. tank/newdata).",

--- a/server/tools_dataset_test.go
+++ b/server/tools_dataset_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDatasetList_NoFilter(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.dataset.query" {
+				t.Errorf("method = %q, want pool.dataset.query", method)
+			}
+			if len(params) != 0 {
+				t.Errorf("expected no params, got %d", len(params))
+			}
+			return json.RawMessage(`[{"id":"tank/data"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestDatasetList_WithPool(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.dataset.query" {
+				t.Errorf("method = %q, want pool.dataset.query", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected filter params, got none")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if len(filter) != 1 || filter[0][0] != "pool" || filter[0][1] != "=" || filter[0][2] != "tank" {
+				t.Errorf("filter = %v, want [[pool = tank]]", filter)
+			}
+			return json.RawMessage(`[{"id":"tank/data"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_list", map[string]any{"pool": "tank"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestDatasetGet_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if len(params) == 0 {
+				t.Fatal("expected filter params")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if filter[0][0] != "id" || filter[0][2] != "tank/data" {
+				t.Errorf("filter = %v, want [[id = tank/data]]", filter)
+			}
+			return json.RawMessage(`{"id":"tank/data"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_get", map[string]any{"path": "tank/data"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestDatasetGet_MissingPath(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_get", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestDatasetCreate_AllParams(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.dataset.create" {
+				t.Errorf("method = %q, want pool.dataset.create", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected params")
+			}
+			p, ok := params[0].(map[string]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want map[string]any", params[0])
+			}
+			if p["name"] != "tank/newdata" {
+				t.Errorf("name = %v, want tank/newdata", p["name"])
+			}
+			if p["comments"] != "test dataset" {
+				t.Errorf("comments = %v, want 'test dataset'", p["comments"])
+			}
+			if p["compression"] != "lz4" {
+				t.Errorf("compression = %v, want lz4", p["compression"])
+			}
+			return json.RawMessage(`{"id":"tank/newdata"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_create", map[string]any{
+		"name":        "tank/newdata",
+		"comments":    "test dataset",
+		"compression": "lz4",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestDatasetCreate_RequiredOnly(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			p := params[0].(map[string]any)
+			if p["name"] != "tank/newdata" {
+				t.Errorf("name = %v, want tank/newdata", p["name"])
+			}
+			if _, ok := p["comments"]; ok {
+				t.Error("unexpected comments key")
+			}
+			if _, ok := p["compression"]; ok {
+				t.Error("unexpected compression key")
+			}
+			return json.RawMessage(`{"id":"tank/newdata"}`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_dataset_create", map[string]any{"name": "tank/newdata"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDatasetCreate_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_create", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestDatasetDelete_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.dataset.delete" {
+				t.Errorf("method = %q, want pool.dataset.delete", method)
+			}
+			if len(params) == 0 || params[0] != "tank/olddata" {
+				t.Errorf("params = %v, want [tank/olddata]", params)
+			}
+			return json.RawMessage(`true`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_delete", map[string]any{"path": "tank/olddata"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestDatasetDelete_MissingPath(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_dataset_delete", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing path")
+	}
+}

--- a/server/tools_pool.go
+++ b/server/tools_pool.go
@@ -8,7 +8,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerPoolTools(s *mcp.Server, client *truenas.Client) {
+func registerPoolTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_pool_list",
 		Description: "List all ZFS pools with name, status, size, and health.",

--- a/server/tools_pool_test.go
+++ b/server/tools_pool_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPoolList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.query" {
+				t.Errorf("method = %q, want pool.query", method)
+			}
+			if len(params) != 0 {
+				t.Errorf("expected no params, got %d", len(params))
+			}
+			return json.RawMessage(`[{"name":"tank","status":"ONLINE"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_pool_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestPoolGet_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "pool.query" {
+				t.Errorf("method = %q, want pool.query", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected filter params, got none")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if len(filter) != 1 || filter[0][0] != "name" || filter[0][1] != "=" || filter[0][2] != "tank" {
+				t.Errorf("filter = %v, want [[name = tank]]", filter)
+			}
+			return json.RawMessage(`[{"name":"tank","status":"ONLINE"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_pool_get", map[string]any{"name": "tank"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestPoolGet_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked for missing param")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_pool_get", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name parameter")
+	}
+}

--- a/server/tools_share.go
+++ b/server/tools_share.go
@@ -8,7 +8,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerShareReadTools(s *mcp.Server, client *truenas.Client) {
+func registerShareReadTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_smb_list",
 		Description: "List all SMB shares with name, path, and enabled status.",
@@ -35,7 +35,7 @@ func registerShareReadTools(s *mcp.Server, client *truenas.Client) {
 
 }
 
-func registerShareWriteTools(s *mcp.Server, client *truenas.Client) {
+func registerShareWriteTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_smb_create",
 		Description: "Create an SMB share. The path must point to an existing dataset mountpoint.",

--- a/server/tools_share_test.go
+++ b/server/tools_share_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSMBList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.smb.query" {
+				t.Errorf("method = %q, want sharing.smb.query", method)
+			}
+			return json.RawMessage(`[{"name":"share1","path":"/mnt/tank/data"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestNFSList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.nfs.query" {
+				t.Errorf("method = %q, want sharing.nfs.query", method)
+			}
+			return json.RawMessage(`[{"path":"/mnt/tank/data"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_nfs_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSMBCreate_AllParams(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.smb.create" {
+				t.Errorf("method = %q, want sharing.smb.create", method)
+			}
+			p := params[0].(map[string]any)
+			if p["name"] != "myshare" {
+				t.Errorf("name = %v, want myshare", p["name"])
+			}
+			if p["path"] != "/mnt/tank/data" {
+				t.Errorf("path = %v, want /mnt/tank/data", p["path"])
+			}
+			if p["comment"] != "test share" {
+				t.Errorf("comment = %v, want 'test share'", p["comment"])
+			}
+			if p["guestok"] != true {
+				t.Errorf("guestok = %v, want true", p["guestok"])
+			}
+			return json.RawMessage(`{"id":1,"name":"myshare"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_create", map[string]any{
+		"name":     "myshare",
+		"path":     "/mnt/tank/data",
+		"comment":  "test share",
+		"guest_ok": true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSMBCreate_RequiredOnly(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			p := params[0].(map[string]any)
+			if p["name"] != "myshare" {
+				t.Errorf("name = %v, want myshare", p["name"])
+			}
+			if p["path"] != "/mnt/tank/data" {
+				t.Errorf("path = %v, want /mnt/tank/data", p["path"])
+			}
+			if _, ok := p["comment"]; ok {
+				t.Error("unexpected comment key")
+			}
+			if _, ok := p["guestok"]; ok {
+				t.Error("unexpected guestok key")
+			}
+			return json.RawMessage(`{"id":1}`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_smb_create", map[string]any{
+		"name": "myshare",
+		"path": "/mnt/tank/data",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSMBCreate_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_create", map[string]any{"path": "/mnt/tank/data"})
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestSMBCreate_MissingPath(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_create", map[string]any{"name": "myshare"})
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestSMBDelete_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.smb.delete" {
+				t.Errorf("method = %q, want sharing.smb.delete", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected params")
+			}
+			// Verify float64→int conversion
+			id, ok := params[0].(int)
+			if !ok {
+				t.Fatalf("params[0] is %T, want int", params[0])
+			}
+			if id != 5 {
+				t.Errorf("id = %d, want 5", id)
+			}
+			return json.RawMessage(`true`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_delete", map[string]any{"id": 5.0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSMBDelete_MissingID(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_smb_delete", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing id")
+	}
+}
+
+func TestNFSCreate_WithNetworksAndHosts(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.nfs.create" {
+				t.Errorf("method = %q, want sharing.nfs.create", method)
+			}
+			p := params[0].(map[string]any)
+			if p["path"] != "/mnt/tank/data" {
+				t.Errorf("path = %v, want /mnt/tank/data", p["path"])
+			}
+			networks, ok := p["networks"].([]any)
+			if !ok || len(networks) == 0 {
+				t.Error("expected networks")
+			}
+			hosts, ok := p["hosts"].([]any)
+			if !ok || len(hosts) == 0 {
+				t.Error("expected hosts")
+			}
+			return json.RawMessage(`{"id":1}`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_nfs_create", map[string]any{
+		"path":     "/mnt/tank/data",
+		"networks": []any{"192.168.1.0/24"},
+		"hosts":    []any{"host1.local"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNFSCreate_RequiredOnly(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			p := params[0].(map[string]any)
+			if p["path"] != "/mnt/tank/data" {
+				t.Errorf("path = %v, want /mnt/tank/data", p["path"])
+			}
+			if _, ok := p["networks"]; ok {
+				t.Error("unexpected networks key")
+			}
+			if _, ok := p["hosts"]; ok {
+				t.Error("unexpected hosts key")
+			}
+			return json.RawMessage(`{"id":1}`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_nfs_create", map[string]any{"path": "/mnt/tank/data"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNFSCreate_MissingPath(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_nfs_create", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestNFSDelete_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "sharing.nfs.delete" {
+				t.Errorf("method = %q, want sharing.nfs.delete", method)
+			}
+			id, ok := params[0].(int)
+			if !ok {
+				t.Fatalf("params[0] is %T, want int", params[0])
+			}
+			if id != 3 {
+				t.Errorf("id = %d, want 3", id)
+			}
+			return json.RawMessage(`true`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_nfs_delete", map[string]any{"id": 3.0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNFSDelete_MissingID(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_nfs_delete", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing id")
+	}
+}

--- a/server/tools_snapshot.go
+++ b/server/tools_snapshot.go
@@ -9,7 +9,7 @@ import (
 	"truenas-mcp/truenas"
 )
 
-func registerSnapshotReadTools(s *mcp.Server, client *truenas.Client) {
+func registerSnapshotReadTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_snapshot_list",
 		Description: "List snapshots for a specific dataset with name, creation time, and referenced size.",
@@ -50,7 +50,7 @@ func registerSnapshotReadTools(s *mcp.Server, client *truenas.Client) {
 
 }
 
-func registerSnapshotWriteTools(s *mcp.Server, client *truenas.Client) {
+func registerSnapshotWriteTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_snapshot_create",
 		Description: "Create a ZFS snapshot. Auto-generates a timestamp name if omitted.",

--- a/server/tools_snapshot_test.go
+++ b/server/tools_snapshot_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestSnapshotList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "zfs.snapshot.query" {
+				t.Errorf("method = %q, want zfs.snapshot.query", method)
+			}
+			if len(params) == 0 {
+				t.Fatal("expected filter params")
+			}
+			filter, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("params[0] is %T, want [][]any", params[0])
+			}
+			if filter[0][0] != "dataset" || filter[0][2] != "tank/data" {
+				t.Errorf("filter = %v, want [[dataset = tank/data]]", filter)
+			}
+			return json.RawMessage(`[{"id":"tank/data@snap1"}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_list", map[string]any{"dataset": "tank/data"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSnapshotList_MissingDataset(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_list", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing dataset")
+	}
+}
+
+func TestSnapshotGet_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if len(params) == 0 {
+				t.Fatal("expected filter params")
+			}
+			filter := params[0].([][]any)
+			if filter[0][0] != "id" || filter[0][2] != "tank/data@snap1" {
+				t.Errorf("filter = %v, want [[id = tank/data@snap1]]", filter)
+			}
+			return json.RawMessage(`{"id":"tank/data@snap1"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_get", map[string]any{"name": "tank/data@snap1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSnapshotGet_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_get", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestSnapshotCreate_WithName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "zfs.snapshot.create" {
+				t.Errorf("method = %q, want zfs.snapshot.create", method)
+			}
+			p := params[0].(map[string]any)
+			if p["dataset"] != "tank/data" {
+				t.Errorf("dataset = %v, want tank/data", p["dataset"])
+			}
+			if p["name"] != "mysnap" {
+				t.Errorf("name = %v, want mysnap", p["name"])
+			}
+			return json.RawMessage(`{"id":"tank/data@mysnap"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_create", map[string]any{
+		"dataset": "tank/data",
+		"name":    "mysnap",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSnapshotCreate_AutoName(t *testing.T) {
+	autoNameRe := regexp.MustCompile(`^auto-\d{8}-\d{6}$`)
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			p := params[0].(map[string]any)
+			name, ok := p["name"].(string)
+			if !ok {
+				t.Fatal("name is not a string")
+			}
+			if !autoNameRe.MatchString(name) {
+				t.Errorf("auto name %q does not match pattern auto-YYYYMMDD-HHMMSS", name)
+			}
+			return json.RawMessage(`{"id":"tank/data@` + name + `"}`), nil
+		},
+	}
+	_, err := callTool(t, mock, false, "truenas_snapshot_create", map[string]any{"dataset": "tank/data"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSnapshotCreate_MissingDataset(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_create", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing dataset")
+	}
+}
+
+func TestSnapshotDelete_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "zfs.snapshot.delete" {
+				t.Errorf("method = %q, want zfs.snapshot.delete", method)
+			}
+			if len(params) == 0 || params[0] != "tank/data@snap1" {
+				t.Errorf("params = %v, want [tank/data@snap1]", params)
+			}
+			return json.RawMessage(`true`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_delete", map[string]any{"name": "tank/data@snap1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSnapshotDelete_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_snapshot_delete", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}

--- a/server/tools_system.go
+++ b/server/tools_system.go
@@ -61,7 +61,7 @@ func jsonResult(raw json.RawMessage) (*mcp.CallToolResult, error) {
 	}, nil
 }
 
-func registerSystemTools(s *mcp.Server, client *truenas.Client) {
+func registerSystemTools(s *mcp.Server, client truenas.Caller) {
 	s.AddTool(&mcp.Tool{
 		Name:        "truenas_system_info",
 		Description: "Get TrueNAS system information including hostname, version, uptime, and platform.",

--- a/server/tools_system_test.go
+++ b/server/tools_system_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestSystemInfo_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "system.info" {
+				t.Errorf("method = %q, want system.info", method)
+			}
+			return json.RawMessage(`{"hostname":"nas","version":"24.04"}`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_system_info", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestSystemInfo_Error(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_system_info", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error, got success")
+	}
+}
+
+func TestDiskList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "disk.query" {
+				t.Errorf("method = %q, want disk.query", method)
+			}
+			return json.RawMessage(`[{"name":"sda","size":1000000}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_disk_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}
+
+func TestNetworkList_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "interface.query" {
+				t.Errorf("method = %q, want interface.query", method)
+			}
+			return json.RawMessage(`[{"name":"eth0","state":{"link_state":"LINK_STATE_UP"}}]`), nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_network_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := resultText(t, result)
+	if text == "" {
+		t.Error("result text is empty")
+	}
+}

--- a/truenas/client.go
+++ b/truenas/client.go
@@ -7,6 +7,12 @@ import (
 	"github.com/truenas/api_client_golang/truenas_api"
 )
 
+// Caller is the interface for making TrueNAS JSON-RPC calls.
+// *Client satisfies this interface.
+type Caller interface {
+	Call(method string, params ...interface{}) (json.RawMessage, error)
+}
+
 // Client wraps the TrueNAS WebSocket JSON-RPC client.
 type Client struct {
 	api *truenas_api.Client


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite to the project, addressing the constraint that we can't test against a real TrueNAS server. Introduces a `Caller` interface in the `truenas` package to decouple the server from the concrete client, enabling mock-based testing of all MCP tool handlers. Tests cover helper utilities, CLI flag/env parsing, and every tool category (alerts, apps, datasets, pools) including both happy paths and input validation.

## Changes

- Introduced `truenas.Caller` interface and updated `server.New()` and all tool registration functions to accept it instead of `*truenas.Client`, enabling dependency injection for tests
- Added `server/mock_test.go` with a `mockCaller` implementation and `callTool` helper that wires up an in-memory MCP client/server pair for end-to-end tool invocation in tests
- Added `server/helpers_test.go` covering schema builders (`schema`, `noArgs`, `stringProp`, `numberProp`, `boolProp`, `arrayProp`), argument parsing (`args`), and JSON result formatting (`jsonResult`)
- Added tool-level tests for alerts, apps, datasets, and pools — verifying correct API method dispatch, parameter passing, filter construction, and missing-argument validation
- Added `cmd/serve_test.go` testing `envOrDefault` behavior and CLI validation (missing host, missing API key, read-only env quirk)
- Added `server/server_test.go` verifying server construction in read-only and read-write modes, and that write tools are unavailable in read-only mode

Closes #4