### PR TITLE
refactor: Make API call timeout configurable

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"truenas-mcp/server"
@@ -13,6 +14,7 @@ type serveConfig struct {
 	Host     string
 	APIKey   string
 	ReadOnly bool
+	Timeout  int
 }
 
 func NewServeCmd() *cobra.Command {
@@ -32,7 +34,7 @@ func NewServeCmd() *cobra.Command {
 
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Connecting to TrueNAS at %s...\n", cfg.Host)
 
-			client, err := truenas.Connect(cfg.Host, cfg.APIKey)
+			client, err := truenas.Connect(cfg.Host, cfg.APIKey, cfg.Timeout)
 			if err != nil {
 				return fmt.Errorf("failed to connect to TrueNAS: %w", err)
 			}
@@ -54,6 +56,7 @@ func NewServeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&cfg.Host, "host", envOrDefault("TRUENAS_HOST", ""), "TrueNAS host address (e.g., truenas.local)")
 	cmd.Flags().StringVar(&cfg.APIKey, "api-key", envOrDefault("TRUENAS_API_KEY", ""), "TrueNAS API key")
 	cmd.Flags().BoolVar(&cfg.ReadOnly, "read-only", envOrDefault("TRUENAS_READ_ONLY", "") != "", "Restrict to read-only tools (no create/delete/update operations)")
+	cmd.Flags().IntVar(&cfg.Timeout, "timeout", envOrDefaultInt("TRUENAS_TIMEOUT", 30), "Per-call timeout in seconds for TrueNAS API requests")
 
 	return cmd
 }
@@ -61,6 +64,15 @@ func NewServeCmd() *cobra.Command {
 func envOrDefault(key, fallback string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
+	}
+	return fallback
+}
+
+func envOrDefaultInt(key string, fallback int) int {
+	if val := os.Getenv(key); val != "" {
+		if n, err := strconv.Atoi(val); err == nil {
+			return n
+		}
 	}
 	return fallback
 }

--- a/truenas/client.go
+++ b/truenas/client.go
@@ -16,7 +16,7 @@ type Caller interface {
 // Client wraps the TrueNAS WebSocket JSON-RPC client.
 type Client struct {
 	api     *truenas_api.Client
-	timeout int
+	timeout int64
 }
 
 // Connect establishes a WebSocket connection to TrueNAS and authenticates with an API key.
@@ -38,7 +38,7 @@ func Connect(host, apiKey string, timeout int) (*Client, error) {
 		return nil, fmt.Errorf("authenticating with TrueNAS: %w", err)
 	}
 
-	return &Client{api: api, timeout: timeout}, nil
+	return &Client{api: api, timeout: int64(timeout)}, nil
 }
 
 // Close cleanly shuts down the WebSocket connection.

--- a/truenas/client.go
+++ b/truenas/client.go
@@ -15,11 +15,16 @@ type Caller interface {
 
 // Client wraps the TrueNAS WebSocket JSON-RPC client.
 type Client struct {
-	api *truenas_api.Client
+	api     *truenas_api.Client
+	timeout int
 }
 
 // Connect establishes a WebSocket connection to TrueNAS and authenticates with an API key.
-func Connect(host, apiKey string) (*Client, error) {
+// The timeout parameter specifies the per-call timeout in seconds for API requests.
+func Connect(host, apiKey string, timeout int) (*Client, error) {
+	if timeout <= 0 {
+		timeout = 30
+	}
 	url := fmt.Sprintf("wss://%s/api/current", host)
 
 	// verifySSL=false to support self-signed certs common on NAS devices
@@ -33,7 +38,7 @@ func Connect(host, apiKey string) (*Client, error) {
 		return nil, fmt.Errorf("authenticating with TrueNAS: %w", err)
 	}
 
-	return &Client{api: api}, nil
+	return &Client{api: api, timeout: timeout}, nil
 }
 
 // Close cleanly shuts down the WebSocket connection.
@@ -50,7 +55,7 @@ func (c *Client) Call(method string, params ...interface{}) (json.RawMessage, er
 		params = []interface{}{}
 	}
 
-	raw, err := c.api.Call(method, 30, params)
+	raw, err := c.api.Call(method, c.timeout, params)
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", method, err)
 	}


### PR DESCRIPTION
The TrueNAS API call timeout is hardcoded to 30 seconds in `truenas/client.go:53` (`c.api.Call(method, 30, params)`). Some TrueNAS operations — particularly app start/stop/restart, large dataset creation/deletion, and snapshot operations on large datasets — can take significantly longer than 30 seconds, causing spurious timeout errors.

Add a `Timeout` field to `truenas.Client` (defaulting to 30 seconds), expose it as a `--timeout` CLI flag and `TRUENAS_TIMEOUT` env var in `cmd/serve.go`, and pass it through `Connect()` or a setter. This requires changes to:
- `truenas/client.go`: Add `timeout` field to `Client` struct, use it in `Call()` instead of the literal `30`
- `cmd/serve.go`: Add `--timeout` flag to `serveConfig` and wire it through to `truenas.Connect()` or set it on the client after connection

---
*Automated improvement by yeti improvement-identifier*