### PR TITLE
Make TrueNAS MCP read-only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make
 ## Usage
 
 ```bash
-# with flags
+# safe default: read-only tools only
 truenas-mcp serve --host truenas.local --api-key YOUR_API_KEY
 
 # with environment variables
@@ -27,18 +27,23 @@ export TRUENAS_HOST=truenas.local
 export TRUENAS_API_KEY=YOUR_API_KEY
 truenas-mcp serve
 
-# read-only mode — only query tools, no create/delete/update operations
-truenas-mcp serve --host truenas.local --api-key YOUR_API_KEY --read-only
+# opt into mutating tools only when you intentionally want writes
+truenas-mcp serve --host truenas.local --api-key YOUR_API_KEY --enable-writes
 
-# read-only mode via environment variable
-TRUENAS_READ_ONLY=1 truenas-mcp serve
+# opt into mutating tools via environment variable
+TRUENAS_ENABLE_WRITES=true truenas-mcp serve
+
+# allow self-signed certificates only when explicitly needed
+truenas-mcp serve --host truenas.local --api-key YOUR_API_KEY --tls-insecure
 ```
 
-### Read-Only Mode
+### Read-Only by Default
 
-Pass `--read-only` (or set `TRUENAS_READ_ONLY` to any non-empty value) to restrict the MCP server to read-only tools only. When enabled, tools that create, delete, or modify resources are not registered — AI clients cannot see or invoke them.
+The MCP server starts in read-only mode unless you explicitly pass `--enable-writes` or set `TRUENAS_ENABLE_WRITES=true`. In the default mode, tools that create, delete, or modify resources are not registered — AI clients cannot see or invoke them.
 
-This is useful when you want AI assistants to query your NAS without any risk of accidental changes.
+This fail-closed default is intended to make first contact with a TrueNAS system safe. Keep the server read-only until you have tested the tool responses against your NAS.
+
+TLS certificate verification is enabled by default. If your TrueNAS appliance uses a self-signed certificate, pass `--tls-insecure` or set `TRUENAS_TLS_INSECURE=true` after you understand the tradeoff.
 
 ## MCP Configuration
 
@@ -55,14 +60,14 @@ Add to your Claude Code MCP settings (`~/.claude/settings.json`):
 }
 ```
 
-For read-only mode:
+For write-enabled mode:
 
 ```json
 {
   "mcpServers": {
     "truenas": {
       "command": "/path/to/truenas-mcp",
-      "args": ["serve", "--host", "truenas.local", "--api-key", "YOUR_API_KEY", "--read-only"]
+      "args": ["serve", "--host", "truenas.local", "--api-key", "YOUR_API_KEY", "--enable-writes"]
     }
   }
 }
@@ -70,7 +75,7 @@ For read-only mode:
 
 ## Available Tools
 
-Tools marked with `*` are excluded in `--read-only` mode.
+Tools marked with `*` are excluded by default and are registered only with `--enable-writes` or `TRUENAS_ENABLE_WRITES=true`.
 
 | Tool | Description |
 |------|-------------|

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,9 +10,10 @@ import (
 )
 
 type serveConfig struct {
-	Host     string
-	APIKey   string
-	ReadOnly bool
+	Host         string
+	APIKey       string
+	EnableWrites bool
+	TLSInsecure  bool
 }
 
 func NewServeCmd() *cobra.Command {
@@ -32,7 +33,7 @@ func NewServeCmd() *cobra.Command {
 
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Connecting to TrueNAS at %s...\n", cfg.Host)
 
-			client, err := truenas.Connect(cfg.Host, cfg.APIKey)
+			client, err := truenas.Connect(cfg.Host, cfg.APIKey, cfg.TLSInsecure)
 			if err != nil {
 				return fmt.Errorf("failed to connect to TrueNAS: %w", err)
 			}
@@ -40,12 +41,12 @@ func NewServeCmd() *cobra.Command {
 
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Connected and authenticated.\n")
 
-			mcpServer := server.New(client, cfg.ReadOnly)
+			mcpServer := server.New(client, !cfg.EnableWrites)
 
-			if cfg.ReadOnly {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Starting MCP server on stdio (read-only mode)...\n")
+			if cfg.EnableWrites {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Starting MCP server on stdio (writes enabled)...\n")
 			} else {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Starting MCP server on stdio...\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Starting MCP server on stdio (read-only mode)...\n")
 			}
 			return server.Run(cmd.Context(), mcpServer)
 		},
@@ -53,7 +54,8 @@ func NewServeCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&cfg.Host, "host", envOrDefault("TRUENAS_HOST", ""), "TrueNAS host address (e.g., truenas.local)")
 	cmd.Flags().StringVar(&cfg.APIKey, "api-key", envOrDefault("TRUENAS_API_KEY", ""), "TrueNAS API key")
-	cmd.Flags().BoolVar(&cfg.ReadOnly, "read-only", envOrDefault("TRUENAS_READ_ONLY", "") != "", "Restrict to read-only tools (no create/delete/update operations)")
+	cmd.Flags().BoolVar(&cfg.EnableWrites, "enable-writes", envBool("TRUENAS_ENABLE_WRITES", false), "Register tools that create, delete, or modify TrueNAS resources")
+	cmd.Flags().BoolVar(&cfg.TLSInsecure, "tls-insecure", envBool("TRUENAS_TLS_INSECURE", false), "Skip TLS certificate verification when connecting to TrueNAS")
 
 	return cmd
 }
@@ -63,4 +65,19 @@ func envOrDefault(key, fallback string) string {
 		return val
 	}
 	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	val := os.Getenv(key)
+	if val == "" {
+		return fallback
+	}
+	switch val {
+	case "1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES", "Yes", "on", "ON", "On":
+		return true
+	case "0", "f", "F", "false", "FALSE", "False", "n", "N", "no", "NO", "No", "off", "OFF", "Off":
+		return false
+	default:
+		return fallback
+	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -32,7 +32,8 @@ func TestEnvOrDefault_Empty(t *testing.T) {
 func TestServeCmd_MissingHost(t *testing.T) {
 	t.Setenv("TRUENAS_HOST", "")
 	t.Setenv("TRUENAS_API_KEY", "")
-	t.Setenv("TRUENAS_READ_ONLY", "")
+	t.Setenv("TRUENAS_ENABLE_WRITES", "")
+	t.Setenv("TRUENAS_TLS_INSECURE", "")
 
 	cmd := NewServeCmd()
 	cmd.SetArgs([]string{})
@@ -48,7 +49,8 @@ func TestServeCmd_MissingHost(t *testing.T) {
 func TestServeCmd_MissingAPIKey(t *testing.T) {
 	t.Setenv("TRUENAS_HOST", "")
 	t.Setenv("TRUENAS_API_KEY", "")
-	t.Setenv("TRUENAS_READ_ONLY", "")
+	t.Setenv("TRUENAS_ENABLE_WRITES", "")
+	t.Setenv("TRUENAS_TLS_INSECURE", "")
 
 	cmd := NewServeCmd()
 	cmd.SetArgs([]string{"--host", "fake.local"})
@@ -61,19 +63,62 @@ func TestServeCmd_MissingAPIKey(t *testing.T) {
 	}
 }
 
-func TestServeCmd_ReadOnlyEnvQuirk(t *testing.T) {
-	// Any non-empty value of TRUENAS_READ_ONLY enables read-only mode,
-	// including "false" or "0".
-	t.Setenv("TRUENAS_READ_ONLY", "false")
+func TestServeCmd_WritesDisabledByDefault(t *testing.T) {
+	t.Setenv("TRUENAS_ENABLE_WRITES", "")
 	t.Setenv("TRUENAS_HOST", "")
 	t.Setenv("TRUENAS_API_KEY", "")
 
 	cmd := NewServeCmd()
-	readOnly, err := cmd.Flags().GetBool("read-only")
+	enableWrites, err := cmd.Flags().GetBool("enable-writes")
 	if err != nil {
-		t.Fatalf("getting read-only flag: %v", err)
+		t.Fatalf("getting enable-writes flag: %v", err)
 	}
-	if !readOnly {
-		t.Error("TRUENAS_READ_ONLY='false' should still enable read-only mode (any non-empty value)")
+	if enableWrites {
+		t.Error("writes should be disabled by default")
+	}
+}
+
+func TestServeCmd_EnableWritesEnv(t *testing.T) {
+	t.Setenv("TRUENAS_ENABLE_WRITES", "true")
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+
+	cmd := NewServeCmd()
+	enableWrites, err := cmd.Flags().GetBool("enable-writes")
+	if err != nil {
+		t.Fatalf("getting enable-writes flag: %v", err)
+	}
+	if !enableWrites {
+		t.Error("TRUENAS_ENABLE_WRITES=true should enable writes")
+	}
+}
+
+func TestServeCmd_EnableWritesFalseEnv(t *testing.T) {
+	t.Setenv("TRUENAS_ENABLE_WRITES", "false")
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+
+	cmd := NewServeCmd()
+	enableWrites, err := cmd.Flags().GetBool("enable-writes")
+	if err != nil {
+		t.Fatalf("getting enable-writes flag: %v", err)
+	}
+	if enableWrites {
+		t.Error("TRUENAS_ENABLE_WRITES=false should keep writes disabled")
+	}
+}
+
+func TestServeCmd_TLSInsecureEnv(t *testing.T) {
+	t.Setenv("TRUENAS_TLS_INSECURE", "1")
+	t.Setenv("TRUENAS_HOST", "")
+	t.Setenv("TRUENAS_API_KEY", "")
+
+	cmd := NewServeCmd()
+	tlsInsecure, err := cmd.Flags().GetBool("tls-insecure")
+	if err != nil {
+		t.Fatalf("getting tls-insecure flag: %v", err)
+	}
+	if !tlsInsecure {
+		t.Error("TRUENAS_TLS_INSECURE=1 should skip TLS verification")
 	}
 }

--- a/server/mock_test.go
+++ b/server/mock_test.go
@@ -51,6 +51,42 @@ func callTool(t *testing.T, caller truenas.Caller, readOnly bool, toolName strin
 	})
 }
 
+// listTools creates a server with the given caller, connects an in-memory client,
+// and returns the registered tool names.
+func listTools(t *testing.T, caller truenas.Caller, readOnly bool) []string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	s := New(caller, readOnly)
+	ct, st := mcp.NewInMemoryTransports()
+
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer func() { _ = ss.Close() }()
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
 // resultText extracts the text string from the first TextContent in a CallToolResult.
 func resultText(t *testing.T, r *mcp.CallToolResult) string {
 	t.Helper()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -41,3 +41,32 @@ func TestNew_ReadOnly_NoWriteTools(t *testing.T) {
 		t.Error("expected error calling write tool on read-only server, got nil")
 	}
 }
+
+func TestNew_ReadOnly_ToolListContainsNoWriteTools(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			return json.RawMessage(`{}`), nil
+		},
+	}
+
+	writeTools := map[string]bool{
+		"truenas_dataset_create":  true,
+		"truenas_dataset_delete":  true,
+		"truenas_snapshot_create": true,
+		"truenas_snapshot_delete": true,
+		"truenas_smb_create":      true,
+		"truenas_smb_delete":      true,
+		"truenas_nfs_create":      true,
+		"truenas_nfs_delete":      true,
+		"truenas_alert_dismiss":   true,
+		"truenas_app_start":       true,
+		"truenas_app_stop":        true,
+		"truenas_app_restart":     true,
+	}
+
+	for _, name := range listTools(t, mock, true) {
+		if writeTools[name] {
+			t.Fatalf("read-only server registered write tool %q", name)
+		}
+	}
+}

--- a/truenas/client.go
+++ b/truenas/client.go
@@ -19,11 +19,13 @@ type Client struct {
 }
 
 // Connect establishes a WebSocket connection to TrueNAS and authenticates with an API key.
-func Connect(host, apiKey string) (*Client, error) {
+func Connect(host, apiKey string, tlsInsecure bool) (*Client, error) {
 	url := fmt.Sprintf("wss://%s/api/current", host)
 
-	// verifySSL=false to support self-signed certs common on NAS devices
-	api, err := truenas_api.NewClient(url, false)
+	// TrueNAS appliances often use self-signed certificates, but production clients
+	// should fail closed unless the operator explicitly opts out of verification.
+	verifySSL := !tlsInsecure
+	api, err := truenas_api.NewClient(url, verifySSL)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to TrueNAS at %s: %w", host, err)
 	}

--- a/yeti/tools.md
+++ b/yeti/tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Complete catalog of MCP tools exposed by truenas-mcp. Tools marked with **[write]** are excluded in `--read-only` mode.
+Complete catalog of MCP tools exposed by truenas-mcp. Tools marked with **[write]** are excluded by default and are registered only with `--enable-writes` or `TRUENAS_ENABLE_WRITES=true`.
 
 ## System Tools (`tools_system.go`)
 


### PR DESCRIPTION
## Summary
- make the MCP server fail closed by registering only read-only tools by default
- replace opt-in `--read-only`/`TRUENAS_READ_ONLY` with explicit `--enable-writes`/`TRUENAS_ENABLE_WRITES=true`
- enable TLS verification by default, with `--tls-insecure`/`TRUENAS_TLS_INSECURE=true` as the explicit opt-out
- add tests that prove write tools are not registered in read-only mode
- update README and tool docs for the safer default

## Verification
- `go test ./...`
- `go build ./...`

## Notes
This keeps first contact with a TrueNAS server read-only and makes mutating tools intentionally opt-in before future app update workflows are added.