### PR TITLE
Add read-only TrueNAS health and update reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Tools marked with `*` are excluded by default and are registered only with `--en
 
 | Tool | Description |
 |------|-------------|
+| `truenas_health_report` | Aggregated system, pool, disk, and alert health report |
 | `truenas_system_info` | System hostname, version, uptime, platform |
 | `truenas_disk_list` | Physical disks with health status |
 | `truenas_network_list` | Network interfaces and IPs |
@@ -102,6 +103,8 @@ Tools marked with `*` are excluded by default and are registered only with `--en
 | `truenas_alert_dismiss` | Dismiss an alert `*` |
 | `truenas_app_list` | Installed apps with status |
 | `truenas_app_get` | App details |
+| `truenas_apps_update_report` | Apps with app or container image updates available |
 | `truenas_app_start` | Start an app `*` |
 | `truenas_app_stop` | Stop an app `*` |
 | `truenas_app_restart` | Restart an app `*` |
+| `truenas_jobs_list` | Recent TrueNAS jobs, optionally filtered by state or method |

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ func New(client truenas.Caller, readOnly bool) *mcp.Server {
 	}, nil)
 
 	// Read-only tools — always registered
+	registerHealthReportTools(s, client)
 	registerSystemTools(s, client)
 	registerPoolTools(s, client)
 	registerDatasetReadTools(s, client)
@@ -24,6 +25,7 @@ func New(client truenas.Caller, readOnly bool) *mcp.Server {
 	registerShareReadTools(s, client)
 	registerAlertReadTools(s, client)
 	registerAppReadTools(s, client)
+	registerJobReadTools(s, client)
 
 	// Mutating tools — only when not in read-only mode
 	if !readOnly {

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -38,6 +39,51 @@ func registerAppReadTools(s *mcp.Server, client truenas.Caller) {
 			return nil, fmt.Errorf("app.query: %w", err)
 		}
 		return jsonResult(result)
+	})
+
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_apps_update_report",
+		Description: "Report installed apps with TrueNAS app or container image updates available.",
+		InputSchema: noArgs(),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		result, err := client.Call("app.query")
+		if err != nil {
+			return nil, fmt.Errorf("app.query: %w", err)
+		}
+
+		var apps []map[string]any
+		if err := json.Unmarshal(result, &apps); err != nil {
+			return nil, fmt.Errorf("parsing app.query: %w", err)
+		}
+
+		candidates := []map[string]any{}
+		for _, app := range apps {
+			upgradeAvailable, _ := app["upgrade_available"].(bool)
+			imageUpdatesAvailable, _ := app["image_updates_available"].(bool)
+			if !upgradeAvailable && !imageUpdatesAvailable {
+				continue
+			}
+
+			candidates = append(candidates, map[string]any{
+				"name":                    app["name"],
+				"id":                      app["id"],
+				"state":                   app["state"],
+				"version":                 app["version"],
+				"human_version":           app["human_version"],
+				"latest_version":          app["latest_version"],
+				"upgrade_available":       upgradeAvailable,
+				"image_updates_available": imageUpdatesAvailable,
+			})
+		}
+
+		report := map[string]any{
+			"summary": map[string]any{
+				"apps_total":        len(apps),
+				"updates_available": len(candidates),
+			},
+			"apps": candidates,
+		}
+		return jsonValueResult(report)
 	})
 
 }

--- a/server/tools_app_update_report_test.go
+++ b/server/tools_app_update_report_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAppsUpdateReport_Success(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.query" {
+				t.Fatalf("method = %q, want app.query", method)
+			}
+			return json.RawMessage(`[
+				{"name":"plex","state":"RUNNING","version":"1.0.0","human_version":"1.0.0","latest_version":"1.1.0","upgrade_available":true,"image_updates_available":false},
+				{"name":"home-assistant","state":"RUNNING","version":"2.0.0","upgrade_available":false,"image_updates_available":true},
+				{"name":"syncthing","state":"RUNNING","version":"3.0.0","upgrade_available":false,"image_updates_available":false}
+			]`), nil
+		},
+	}
+
+	result, err := callTool(t, mock, true, "truenas_apps_update_report", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if summary["apps_total"] != float64(3) {
+		t.Errorf("apps_total = %v, want 3", summary["apps_total"])
+	}
+	if summary["updates_available"] != float64(2) {
+		t.Errorf("updates_available = %v, want 2", summary["updates_available"])
+	}
+	apps := report["apps"].([]any)
+	if len(apps) != 2 {
+		t.Fatalf("apps len = %d, want 2", len(apps))
+	}
+}
+
+func TestAppsUpdateReport_NoMutatingCalls(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if strings.Contains(method, "upgrade") || strings.Contains(method, "update") || strings.Contains(method, "refresh") {
+				t.Fatalf("unexpected mutating or noisy method %q", method)
+			}
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	_, err := callTool(t, mock, true, "truenas_apps_update_report", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/server/tools_reports.go
+++ b/server/tools_reports.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"truenas-mcp/truenas"
+)
+
+func jsonValueResult(v any) (*mcp.CallToolResult, error) {
+	pretty, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("formatting result: %w", err)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(pretty)},
+		},
+	}, nil
+}
+
+func registerHealthReportTools(s *mcp.Server, client truenas.Caller) {
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_health_report",
+		Description: "Return a read-only health report aggregated from system state, pools, disks, and alerts.",
+		InputSchema: noArgs(),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		report := map[string]any{
+			"summary": map[string]any{
+				"status":          "ok",
+				"failed_sections": 0,
+				"pools_unhealthy": 0,
+				"alerts_critical": 0,
+				"alerts_warning":  0,
+			},
+			"details": map[string]any{},
+			"errors":  map[string]string{},
+		}
+		summary := report["summary"].(map[string]any)
+		details := report["details"].(map[string]any)
+		errors := report["errors"].(map[string]string)
+
+		addSection := func(name, method string, params ...interface{}) {
+			result, err := client.Call(method, params...)
+			if err != nil {
+				errors[name] = err.Error()
+				summary["failed_sections"] = summary["failed_sections"].(int) + 1
+				return
+			}
+			var parsed any
+			if err := json.Unmarshal(result, &parsed); err != nil {
+				errors[name] = err.Error()
+				summary["failed_sections"] = summary["failed_sections"].(int) + 1
+				return
+			}
+			details[name] = parsed
+		}
+
+		addSection("system", "system.info")
+		addSection("system_state", "system.state")
+		addSection("pools", "pool.query")
+		addSection("disks", "disk.query")
+		addSection("alerts", "alert.list")
+
+		if pools, ok := details["pools"].([]any); ok {
+			unhealthy := 0
+			for _, item := range pools {
+				pool, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if healthy, ok := pool["healthy"].(bool); ok && !healthy {
+					unhealthy++
+					continue
+				}
+				if warning, ok := pool["warning"].(bool); ok && warning {
+					unhealthy++
+					continue
+				}
+				if status, ok := pool["status"].(string); ok && !strings.EqualFold(status, "ONLINE") {
+					unhealthy++
+				}
+			}
+			summary["pools_unhealthy"] = unhealthy
+		}
+
+		if alerts, ok := details["alerts"].([]any); ok {
+			critical := 0
+			warning := 0
+			for _, item := range alerts {
+				alert, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				level, _ := alert["level"].(string)
+				switch strings.ToUpper(level) {
+				case "CRITICAL":
+					critical++
+				case "WARNING", "WARN":
+					warning++
+				}
+			}
+			summary["alerts_critical"] = critical
+			summary["alerts_warning"] = warning
+		}
+
+		if summary["failed_sections"].(int) > 0 || summary["alerts_critical"].(int) > 0 || summary["pools_unhealthy"].(int) > 0 {
+			summary["status"] = "critical"
+		} else if summary["alerts_warning"].(int) > 0 {
+			summary["status"] = "warning"
+		}
+
+		return jsonValueResult(report)
+	})
+}
+
+func registerJobReadTools(s *mcp.Server, client truenas.Caller) {
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_jobs_list",
+		Description: "List recent TrueNAS jobs, optionally filtered by state or method.",
+		InputSchema: schema(map[string]any{
+			"state":  stringProp("optional job state filter: WAITING, RUNNING, SUCCESS, FAILED, or ABORTED"),
+			"method": stringProp("optional job method filter"),
+			"limit":  numberProp("maximum jobs to return, default 50"),
+		}),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		a := args(req)
+		filters := [][]any{}
+		if state, ok := a["state"].(string); ok && state != "" {
+			filters = append(filters, []any{"state", "=", strings.ToUpper(state)})
+		}
+		if method, ok := a["method"].(string); ok && method != "" {
+			filters = append(filters, []any{"method", "=", method})
+		}
+		limit := 50
+		if rawLimit, ok := a["limit"].(float64); ok && rawLimit > 0 {
+			limit = int(rawLimit)
+		}
+		if limit > 200 {
+			limit = 200
+		}
+		options := map[string]any{
+			"order_by": []string{"-time_started"},
+			"limit":    limit,
+		}
+		result, err := client.Call("core.get_jobs", filters, options)
+		if err != nil {
+			return nil, fmt.Errorf("core.get_jobs: %w", err)
+		}
+		return jsonResult(result)
+	})
+}

--- a/server/tools_reports_test.go
+++ b/server/tools_reports_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestHealthReport_SuccessWarning(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "system.info":
+				return json.RawMessage(`{"hostname":"nas","version":"25.10"}`), nil
+			case "system.state":
+				return json.RawMessage(`"READY"`), nil
+			case "pool.query":
+				return json.RawMessage(`[{"name":"tank","healthy":true,"status":"ONLINE"}]`), nil
+			case "disk.query":
+				return json.RawMessage(`[{"name":"sda","model":"disk"}]`), nil
+			case "alert.list":
+				return json.RawMessage(`[{"id":"a1","level":"WARNING","text":"check something"}]`), nil
+			default:
+				t.Fatalf("unexpected method %q", method)
+				return nil, nil
+			}
+		},
+	}
+
+	result, err := callTool(t, mock, true, "truenas_health_report", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if summary["status"] != "warning" {
+		t.Errorf("status = %v, want warning", summary["status"])
+	}
+	if summary["alerts_warning"] != float64(1) {
+		t.Errorf("alerts_warning = %v, want 1", summary["alerts_warning"])
+	}
+
+	wantCalls := []string{"system.info", "system.state", "pool.query", "disk.query", "alert.list"}
+	if fmt.Sprint(calls) != fmt.Sprint(wantCalls) {
+		t.Errorf("calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestHealthReport_PartialFailure(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method == "disk.query" {
+				return nil, fmt.Errorf("disk unavailable")
+			}
+			switch method {
+			case "system.info":
+				return json.RawMessage(`{"hostname":"nas"}`), nil
+			case "system.state":
+				return json.RawMessage(`"READY"`), nil
+			case "pool.query":
+				return json.RawMessage(`[{"name":"tank","healthy":false}]`), nil
+			case "alert.list":
+				return json.RawMessage(`[{"level":"CRITICAL"}]`), nil
+			default:
+				return nil, fmt.Errorf("unexpected method %s", method)
+			}
+		},
+	}
+
+	result, err := callTool(t, mock, true, "truenas_health_report", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	summary := report["summary"].(map[string]any)
+	if summary["status"] != "critical" {
+		t.Errorf("status = %v, want critical", summary["status"])
+	}
+	if summary["failed_sections"] != float64(1) {
+		t.Errorf("failed_sections = %v, want 1", summary["failed_sections"])
+	}
+}
+
+func TestJobsList_WithFilters(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "core.get_jobs" {
+				t.Fatalf("method = %q, want core.get_jobs", method)
+			}
+			if len(params) != 2 {
+				t.Fatalf("params len = %d, want 2", len(params))
+			}
+			filters, ok := params[0].([][]any)
+			if !ok {
+				t.Fatalf("filters = %T, want [][]any", params[0])
+			}
+			if fmt.Sprint(filters) != "[[state = FAILED] [method = app.upgrade]]" {
+				t.Errorf("filters = %v", filters)
+			}
+			options, ok := params[1].(map[string]any)
+			if !ok {
+				t.Fatalf("options = %T, want map[string]any", params[1])
+			}
+			if options["limit"] != 10 {
+				t.Errorf("limit = %v, want 10", options["limit"])
+			}
+			return json.RawMessage(`[{"id":1,"state":"FAILED","method":"app.upgrade"}]`), nil
+		},
+	}
+
+	result, err := callTool(t, mock, true, "truenas_jobs_list", map[string]any{
+		"state":  "failed",
+		"method": "app.upgrade",
+		"limit":  10.0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resultText(t, result) == "" {
+		t.Error("empty result")
+	}
+}
+
+func TestJobsList_LimitClamped(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "core.get_jobs" {
+				t.Fatalf("method = %q, want core.get_jobs", method)
+			}
+			options := params[1].(map[string]any)
+			if options["limit"] != 200 {
+				t.Errorf("limit = %v, want 200", options["limit"])
+			}
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	_, err := callTool(t, mock, true, "truenas_jobs_list", map[string]any{"limit": 1000.0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/yeti/tools.md
+++ b/yeti/tools.md
@@ -4,6 +4,11 @@ Complete catalog of MCP tools exposed by truenas-mcp. Tools marked with **[write
 
 ## System Tools (`tools_system.go`)
 
+### `truenas_health_report`
+Return an aggregated read-only health report from system info, system state, pools, disks, and alerts.
+- Parameters: none
+- APIs: `system.info`, `system.state`, `pool.query`, `disk.query`, `alert.list`
+
 ### `truenas_system_info`
 Get system hostname, version, uptime, and platform.
 - Parameters: none
@@ -155,6 +160,11 @@ Get detailed info for a specific app.
   - `name` (string, required) — app name
 - API: `app.query` with filter `[["name", "=", name]]`
 
+### `truenas_apps_update_report`
+Report installed apps with TrueNAS app or container image updates available.
+- Parameters: none
+- API: `app.query`
+
 ### `truenas_app_start` **[write]**
 Start a stopped app.
 - Parameters:
@@ -172,3 +182,13 @@ Restart an app.
 - Parameters:
   - `name` (string, required) — app name
 - API: `app.restart`
+
+## Job Tools (`tools_reports.go`)
+
+### `truenas_jobs_list`
+List recent TrueNAS jobs, optionally filtered by state or method.
+- Parameters:
+  - `state` (string, optional) — job state (`WAITING`, `RUNNING`, `SUCCESS`, `FAILED`, or `ABORTED`)
+  - `method` (string, optional) — job method name
+  - `limit` (number, optional) — maximum jobs to return, clamped to 200
+- API: `core.get_jobs`


### PR DESCRIPTION
## Summary
- add `truenas_health_report` as a read-only aggregate over system, pool, disk, and alert APIs
- add `truenas_jobs_list` using `core.get_jobs` with state/method filters and a clamped limit
- add `truenas_apps_update_report` from `app.query` update fields only
- document the new read-only tools

## Safety
- no app upgrade/update/refresh methods are called
- no mutating TrueNAS methods are introduced
- health report captures partial section failures instead of forcing extra calls

## Verification
- `make all`
- `make test`
- `go test -race ./server`

Note: `golangci-lint` is not installed locally, so PR CI remains the lint gate.