### PR TITLE
Add first contact guide and stdio smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This fail-closed default is intended to make first contact with a TrueNAS system
 
 TLS certificate verification is enabled by default. If your TrueNAS appliance uses a self-signed certificate, pass `--tls-insecure` or set `TRUENAS_TLS_INSECURE=true` after you understand the tradeoff.
 
+For a step-by-step safe first connection checklist, see [First Contact with TrueNAS](docs/first-contact.md).
+
 ## MCP Configuration
 
 Add to your Claude Code MCP settings (`~/.claude/settings.json`):

--- a/docs/first-contact.md
+++ b/docs/first-contact.md
@@ -1,0 +1,92 @@
+# First Contact with TrueNAS
+
+Use this checklist the first time you connect `truenas-mcp` to a real TrueNAS SCALE system.
+
+The default server mode is read-only. Keep it that way until you have inspected the tools and verified responses from your NAS.
+
+## Safety Rules
+
+- Do **not** pass `--enable-writes` during first contact.
+- Unset `TRUENAS_ENABLE_WRITES` so writes stay disabled by default.
+- Use a dedicated API key. If your TrueNAS version supports scoped or read-only API credentials, use the narrowest scope available.
+- Prefer valid TLS certificates. Use `--tls-insecure` only when you knowingly accept self-signed certificate verification risk.
+- First prompts should only list tools or call read-only report/list tools.
+- Remember that read-only tools can still expose NAS metadata to the connected AI client and its logs.
+
+## Build Locally
+
+```bash
+make build
+```
+
+## Environment
+
+```bash
+unset TRUENAS_ENABLE_WRITES
+export TRUENAS_HOST=truenas.local
+export TRUENAS_API_KEY='paste-api-key-here'
+```
+
+If your appliance uses a self-signed certificate and you accept that risk for first contact:
+
+```bash
+export TRUENAS_TLS_INSECURE=true
+```
+
+## Run Read-Only
+
+```bash
+./truenas-mcp serve --host "$TRUENAS_HOST" --api-key "$TRUENAS_API_KEY"
+```
+
+Do not add `--enable-writes`.
+
+## Claude MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "truenas": {
+      "command": "/absolute/path/to/truenas-mcp",
+      "args": ["serve", "--host", "truenas.local", "--api-key", "YOUR_API_KEY"]
+    }
+  }
+}
+```
+
+For self-signed certificates, add `--tls-insecure` only if needed:
+
+```json
+{
+  "mcpServers": {
+    "truenas": {
+      "command": "/absolute/path/to/truenas-mcp",
+      "args": ["serve", "--host", "truenas.local", "--api-key", "YOUR_API_KEY", "--tls-insecure"]
+    }
+  }
+}
+```
+
+## First Prompts
+
+Start with tool discovery and read-only checks:
+
+- “List the available TrueNAS tools.”
+- “Run `truenas_health_report` and summarize the result.”
+- “Run `truenas_apps_update_report`; do not update anything.”
+- “List recent TrueNAS jobs with `truenas_jobs_list`.”
+
+Avoid any prompt asking the assistant to create, delete, start, stop, restart, upgrade, or modify resources during first contact.
+
+## Expected Read-Only Tools
+
+Representative tools available by default include:
+
+- `truenas_health_report`
+- `truenas_system_info`
+- `truenas_pool_list`
+- `truenas_app_list`
+- `truenas_apps_update_report`
+- `truenas_jobs_list`
+
+Tools with names like `create`, `delete`, `start`, `stop`, `restart`, or `dismiss` should not appear unless you intentionally started the server with `--enable-writes` or `TRUENAS_ENABLE_WRITES=true`.

--- a/server/stdio_smoke_test.go
+++ b/server/stdio_smoke_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const stdioSmokeChildEnv = "TRUENAS_MCP_STDIO_SMOKE_CHILD"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(stdioSmokeChildEnv) == "1" {
+		mock := &mockCaller{
+			CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+				return json.RawMessage(`null`), nil
+			},
+		}
+		server := New(mock, true)
+		if err := Run(context.Background(), server); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestStdioSmoke_ReadOnlyToolList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestStdioSmoke_ReadOnlyToolList")
+	cmd.Env = append(os.Environ(), stdioSmokeChildEnv+"=1")
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "stdio-smoke-test"}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{
+		Command:           cmd,
+		TerminateDuration: time.Second,
+	}, nil)
+	if err != nil {
+		t.Fatalf("connect stdio command transport: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	tools := map[string]bool{}
+	for _, tool := range result.Tools {
+		tools[tool.Name] = true
+	}
+
+	writeTools := []string{
+		"truenas_dataset_create",
+		"truenas_dataset_delete",
+		"truenas_snapshot_create",
+		"truenas_snapshot_delete",
+		"truenas_smb_create",
+		"truenas_smb_delete",
+		"truenas_nfs_create",
+		"truenas_nfs_delete",
+		"truenas_alert_dismiss",
+		"truenas_app_start",
+		"truenas_app_stop",
+		"truenas_app_restart",
+	}
+	for _, name := range writeTools {
+		if tools[name] {
+			t.Fatalf("read-only stdio server registered write tool %q", name)
+		}
+	}
+
+	readTools := []string{
+		"truenas_health_report",
+		"truenas_system_info",
+		"truenas_pool_list",
+		"truenas_dataset_list",
+		"truenas_apps_update_report",
+		"truenas_jobs_list",
+	}
+	for _, name := range readTools {
+		if !tools[name] {
+			t.Fatalf("read-only stdio server missing read tool %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a first-contact guide for safely connecting to a real TrueNAS system in read-only mode
- link the guide from the README
- add a stdio MCP smoke test that lists tools through command transport without contacting TrueNAS
- assert write tools are absent and representative read-only tools are present by default

## Safety
- smoke test uses a mock TrueNAS caller only
- first-contact docs warn against `--enable-writes` and call out metadata exposure

## Verification
- `go test -run TestStdioSmoke_ReadOnlyToolList ./server`
- `make all`
- `make test`
- `make lint`