### PR TITLE
Add GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Report a reproducible problem with truenas-mcp
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Do not include API keys, private hostnames, screenshots with secrets, or detailed security reports in public issues.
+  - type: input
+    id: version
+    attributes:
+      label: truenas-mcp version or commit
+      description: Paste the release version or commit SHA you are running.
+      placeholder: "commit SHA or version"
+    validations:
+      required: true
+  - type: input
+    id: truenas-version
+    attributes:
+      label: TrueNAS SCALE version
+      placeholder: "25.10.x"
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: Where are you running truenas-mcp?
+      placeholder: "Linux, macOS, Windows, container, etc."
+    validations:
+      required: false
+  - type: input
+    id: mcp-client
+    attributes:
+      label: MCP client
+      description: Which MCP client are you using?
+      placeholder: "Claude Code, Claude Desktop, OpenClaw, etc."
+    validations:
+      required: false
+  - type: textarea
+    id: config
+    attributes:
+      label: Sanitized command or MCP config
+      description: Remove API keys, private hostnames, and other secrets before pasting.
+      render: text
+    validations:
+      required: false
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Server mode
+      options:
+        - read-only default
+        - writes enabled with --enable-writes / TRUENAS_ENABLE_WRITES=true
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include MCP tool names and sanitized inputs when useful.
+      placeholder: |
+        1. Start server with ...
+        2. Call tool ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant logs after removing API keys, private hostnames, and NAS-private details.
+      render: text
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed API keys and secrets from this report.
+          required: true
+        - label: This is not a detailed security vulnerability report. If it is, I will follow SECURITY.md instead.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an improvement or new TrueNAS MCP capability
+title: "feat: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. For write-capable tools, please describe the safety model as well as the feature.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should truenas-mcp do?
+    validations:
+      required: true
+  - type: dropdown
+    id: safety
+    attributes:
+      label: Safety impact
+      options:
+        - read-only only
+        - write-capable / mutates TrueNAS state
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: api
+    attributes:
+      label: Relevant TrueNAS API methods or docs
+      description: Link or list known TrueNAS SCALE API methods if you have them.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Include workarounds or different designs.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+- 
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New read-only tool or report
+- [ ] Write-capable tool or behavior
+- [ ] Documentation
+- [ ] Tests / CI / maintenance
+
+## Verification
+
+Recommended commands run locally:
+
+- [ ] `make all`
+- [ ] `make test`
+- [ ] `make lint`
+- [ ] Other: 
+
+## Safety notes
+
+- [ ] This change keeps read-only mode fail-closed by default.
+- [ ] This change does not introduce write-capable behavior.
+- [ ] This change introduces or modifies write-capable behavior and documents the opt-in safety model.
+- [ ] I removed API keys, private hostnames, and NAS-private details from logs, fixtures, and screenshots.
+
+## Linked issues
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to truenas-mcp
+
+Thanks for helping improve `truenas-mcp`. This project exposes TrueNAS SCALE management through MCP, so safety matters: read-only behavior should stay the default, and write-capable changes need extra care.
+
+## Before You Start
+
+- Check existing issues and pull requests to avoid duplicate work.
+- For bugs, include your TrueNAS SCALE version, `truenas-mcp` commit/version, OS, and a minimal reproduction.
+- Do not include API keys, hostnames you consider private, full NAS inventory, or other secrets in public issues.
+
+## Local Setup
+
+Requirements:
+
+- Go 1.26+
+- `golangci-lint` for local linting
+
+Build:
+
+```bash
+make build
+```
+
+Run tests:
+
+```bash
+make test
+```
+
+Run the recommended local gates before a PR:
+
+```bash
+make all   # formats, vets, and builds
+make test
+make lint
+```
+
+For first contact with a real TrueNAS system, use the read-only guide:
+
+```bash
+scripts/first-contact.sh
+```
+
+See [`docs/first-contact.md`](docs/first-contact.md) for details.
+
+## Pull Request Expectations
+
+A good PR includes:
+
+- a clear summary of the change
+- tests for new behavior or a short explanation when tests do not apply
+- local verification commands run before pushing
+- safety notes for anything that touches TrueNAS writes, authentication, TLS, or exposed metadata
+
+Write-capable tools must remain opt-in behind `--enable-writes` / `TRUENAS_ENABLE_WRITES=true` and should fail closed by default.
+
+## Project Style
+
+- Keep tool output structured and easy for MCP clients to summarize.
+- Prefer small, focused PRs.
+- Keep docs honest: do not promise support, compatibility, or security response times unless they are actually available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+`truenas-mcp` connects AI clients to TrueNAS SCALE. Please treat security and privacy issues carefully, especially anything involving API keys, write-capable tools, TLS handling, or unintended exposure of NAS metadata.
+
+## Supported Versions
+
+The `main` branch is the actively maintained version unless a release policy is documented later.
+
+## Reporting a Vulnerability
+
+Please do not post API keys, private hostnames, logs with secrets, or detailed exploit information in a public issue.
+
+Preferred reporting path:
+
+1. Use GitHub's private vulnerability reporting / Security Advisory flow for this repository if it is available.
+2. If private reporting is not available, open a public issue with a minimal description such as “security report contact needed” and omit sensitive details.
+
+## What to Include
+
+When reporting privately, include:
+
+- affected commit or version
+- TrueNAS SCALE version, if relevant
+- impact and expected vs actual behavior
+- reproduction steps or proof of concept, if safe to share privately
+- whether API keys, write tools, TLS verification, or logs are involved
+
+## Safety Notes
+
+- Read-only mode is the default and should remain fail-closed.
+- Write-capable tools must require explicit opt-in with `--enable-writes` or `TRUENAS_ENABLE_WRITES=true`.
+- Read-only tools can still expose NAS metadata to the connected AI client and its logs.
+- Do not share real API keys in issues, pull requests, screenshots, or CI logs.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+# Support
+
+`truenas-mcp` is a community project for exposing TrueNAS SCALE capabilities through MCP.
+
+## Where to Ask
+
+- Use GitHub Issues for reproducible bugs and feature requests.
+- Use pull requests for proposed fixes and improvements.
+- For security-sensitive reports, see [`SECURITY.md`](SECURITY.md) instead of opening a detailed public issue.
+
+## Before Opening an Issue
+
+Please include:
+
+- `truenas-mcp` commit or version
+- TrueNAS SCALE version
+- operating system and Go version, if building locally
+- command or MCP client configuration, with API keys removed
+- expected behavior and actual behavior
+- relevant logs with secrets, hostnames, and NAS-private details redacted
+
+## Scope
+
+Good fits for this repository:
+
+- MCP server bugs
+- TrueNAS SCALE API compatibility issues
+- read-only safety issues
+- app, job, pool, alert, dataset, share, or snapshot tool behavior
+- documentation improvements
+
+Out of scope:
+
+- general TrueNAS administration support
+- recovery from destructive storage operations
+- support for leaked API keys or compromised systems
+- guaranteed response times
+
+If you are connecting to a real TrueNAS system for the first time, start with [`docs/first-contact.md`](docs/first-contact.md).


### PR DESCRIPTION
## Summary
- add repo-aware CONTRIBUTING, SECURITY, and SUPPORT docs
- add bug report and feature request issue forms
- add a pull request template with verification and safety prompts

## Notes
- CODE_OF_CONDUCT.md is intentionally not included yet because it should have a real enforcement/reporting path before being adopted
- docs avoid invented contact emails, support SLAs, or security promises

## Verification
- parsed issue template YAML with Python/PyYAML
- `make all`
- `make test`
- `make lint`