### PR TITLE
feat(apps): add app update tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,6 @@ Tools marked with `*` are excluded by default and are registered only with `--en
 | `truenas_app_start` | Start an app `*` |
 | `truenas_app_stop` | Stop an app `*` |
 | `truenas_app_restart` | Restart an app `*` |
+| `truenas_app_update` | Upgrade an app to the latest available version `*` |
+| `truenas_app_update_all` | Upgrade all apps with updates available `*` |
 | `truenas_jobs_list` | Recent TrueNAS jobs, optionally filtered by state or method |

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -62,6 +62,8 @@ func TestNew_ReadOnly_ToolListContainsNoWriteTools(t *testing.T) {
 		"truenas_app_start":       true,
 		"truenas_app_stop":        true,
 		"truenas_app_restart":     true,
+		"truenas_app_update":      true,
+		"truenas_app_update_all":  true,
 	}
 
 	for _, name := range listTools(t, mock, true) {

--- a/server/stdio_smoke_test.go
+++ b/server/stdio_smoke_test.go
@@ -69,6 +69,8 @@ func TestStdioSmoke_ReadOnlyToolList(t *testing.T) {
 		"truenas_app_start",
 		"truenas_app_stop",
 		"truenas_app_restart",
+		"truenas_app_update",
+		"truenas_app_update_all",
 	}
 	for _, name := range writeTools {
 		if tools[name] {

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -145,4 +145,105 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 		}
 		return jsonResult(result)
 	})
+
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_app_update",
+		Description: "Upgrade a named app to its latest available version and return the TrueNAS job ID.",
+		InputSchema: schema(map[string]any{
+			"name": stringProp("app name to upgrade"),
+		}, "name"),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		a := args(req)
+		name, ok := a["name"].(string)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("required parameter 'name' missing")
+		}
+
+		result, err := client.Call("app.query", [][]any{{"name", "=", name}})
+		if err != nil {
+			return nil, fmt.Errorf("app.query: %w", err)
+		}
+
+		var apps []map[string]any
+		if err := json.Unmarshal(result, &apps); err != nil {
+			return nil, fmt.Errorf("parsing app.query: %w", err)
+		}
+		if len(apps) == 0 {
+			return nil, fmt.Errorf("app %q not found", name)
+		}
+		upgradeAvailable, _ := apps[0]["upgrade_available"].(bool)
+		if !upgradeAvailable {
+			return nil, fmt.Errorf("app %q has no update available", name)
+		}
+
+		jobID, err := upgradeApp(client, name)
+		if err != nil {
+			return nil, err
+		}
+		return jsonValueResult(map[string]any{
+			"name":   name,
+			"job_id": jobID,
+		})
+	})
+
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_app_update_all",
+		Description: "Upgrade all apps with updates available and return the TrueNAS job IDs.",
+		InputSchema: noArgs(),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		result, err := client.Call("app.query", [][]any{{"upgrade_available", "=", true}})
+		if err != nil {
+			return nil, fmt.Errorf("app.query: %w", err)
+		}
+
+		var apps []map[string]any
+		if err := json.Unmarshal(result, &apps); err != nil {
+			return nil, fmt.Errorf("parsing app.query: %w", err)
+		}
+
+		jobs := []map[string]any{}
+		for _, app := range apps {
+			upgradeAvailable, _ := app["upgrade_available"].(bool)
+			if !upgradeAvailable {
+				continue
+			}
+			name, ok := app["name"].(string)
+			if !ok || name == "" {
+				return nil, fmt.Errorf("app.query returned app without a name")
+			}
+			jobID, err := upgradeApp(client, name)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, map[string]any{
+				"name":   name,
+				"job_id": jobID,
+			})
+		}
+
+		return jsonValueResult(map[string]any{
+			"summary": map[string]any{
+				"updates_available": len(apps),
+				"jobs_started":      len(jobs),
+			},
+			"jobs": jobs,
+		})
+	})
+}
+
+func upgradeApp(client truenas.Caller, name string) (any, error) {
+	result, err := client.Call("app.upgrade", name, map[string]any{
+		"app_version":        "latest",
+		"values":             map[string]any{},
+		"snapshot_hostpaths": false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("app.upgrade: %w", err)
+	}
+
+	var jobID any
+	if err := json.Unmarshal(result, &jobID); err != nil {
+		return nil, fmt.Errorf("parsing app.upgrade: %w", err)
+	}
+	return jobID, nil
 }

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -202,6 +202,7 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 		}
 
 		jobs := []map[string]any{}
+		failures := []map[string]any{}
 		for _, app := range apps {
 			upgradeAvailable, _ := app["upgrade_available"].(bool)
 			if !upgradeAvailable {
@@ -209,11 +210,18 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			}
 			name, ok := app["name"].(string)
 			if !ok || name == "" {
-				return nil, fmt.Errorf("app.query returned app without a name")
+				failures = append(failures, map[string]any{
+					"error": "app.query returned app without a name",
+				})
+				continue
 			}
 			jobID, err := upgradeApp(client, name)
 			if err != nil {
-				return nil, err
+				failures = append(failures, map[string]any{
+					"name":  name,
+					"error": err.Error(),
+				})
+				continue
 			}
 			jobs = append(jobs, map[string]any{
 				"name":   name,
@@ -225,8 +233,10 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"summary": map[string]any{
 				"updates_available": len(apps),
 				"jobs_started":      len(jobs),
+				"failures":          len(failures),
 			},
-			"jobs": jobs,
+			"jobs":     jobs,
+			"failures": failures,
 		})
 	})
 }

--- a/server/tools_app_test.go
+++ b/server/tools_app_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -171,5 +172,155 @@ func TestAppRestart_MissingName(t *testing.T) {
 	result, err := callTool(t, mock, false, "truenas_app_restart", nil)
 	if err == nil && (result == nil || !result.IsError) {
 		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppUpdate_SuccessReturnsJobID(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				if len(params) != 1 {
+					t.Fatalf("app.query params = %v, want name filter", params)
+				}
+				filter, ok := params[0].([][]any)
+				if !ok {
+					t.Fatalf("app.query params[0] is %T, want [][]any", params[0])
+				}
+				if len(filter) != 1 || filter[0][0] != "name" || filter[0][1] != "=" || filter[0][2] != "plex" {
+					t.Fatalf("app.query filter = %v, want [[name = plex]]", filter)
+				}
+				return json.RawMessage(`[{"name":"plex","upgrade_available":true}]`), nil
+			case "app.upgrade":
+				if len(params) != 2 || params[0] != "plex" {
+					t.Fatalf("app.upgrade params = %v, want [plex options]", params)
+				}
+				options, ok := params[1].(map[string]any)
+				if !ok {
+					t.Fatalf("app.upgrade options is %T, want map[string]any", params[1])
+				}
+				if options["app_version"] != "latest" {
+					t.Fatalf("app_version = %v, want latest", options["app_version"])
+				}
+				return json.RawMessage(`123`), nil
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload["name"] != "plex" {
+		t.Errorf("name = %v, want plex", payload["name"])
+	}
+	if payload["job_id"] != float64(123) {
+		t.Errorf("job_id = %v, want 123", payload["job_id"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade]", calls)
+	}
+}
+
+func TestAppUpdate_NoUpdateAvailableReturnsError(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.query" {
+				t.Fatalf("method = %q, want app.query", method)
+			}
+			return json.RawMessage(`[{"name":"plex","upgrade_available":false}]`), nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update", map[string]any{"name": "plex"})
+	if err == nil && (result == nil || !result.IsError) {
+		t.Fatal("expected error for app with no update available")
+	}
+}
+
+func TestAppUpdate_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_update", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppUpdateAll_SuccessReturnsJobIDs(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				if len(params) != 1 {
+					t.Fatalf("app.query params = %v, want upgrade_available filter", params)
+				}
+				filter, ok := params[0].([][]any)
+				if !ok {
+					t.Fatalf("app.query params[0] is %T, want [][]any", params[0])
+				}
+				if len(filter) != 1 || filter[0][0] != "upgrade_available" || filter[0][1] != "=" || filter[0][2] != true {
+					t.Fatalf("app.query filter = %v, want [[upgrade_available = true]]", filter)
+				}
+				return json.RawMessage(`[
+					{"name":"plex","upgrade_available":true},
+					{"name":"syncthing","upgrade_available":true}
+				]`), nil
+			case "app.upgrade":
+				if len(params) != 2 {
+					t.Fatalf("app.upgrade params = %v, want [name options]", params)
+				}
+				switch params[0] {
+				case "plex":
+					return json.RawMessage(`201`), nil
+				case "syncthing":
+					return json.RawMessage(`202`), nil
+				default:
+					t.Fatalf("unexpected app.upgrade app %v", params[0])
+				}
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update_all", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	jobs := payload["jobs"].([]any)
+	if len(jobs) != 2 {
+		t.Fatalf("jobs len = %d, want 2", len(jobs))
+	}
+	if jobs[0].(map[string]any)["job_id"] != float64(201) {
+		t.Errorf("first job_id = %v, want 201", jobs[0].(map[string]any)["job_id"])
+	}
+	if jobs[1].(map[string]any)["job_id"] != float64(202) {
+		t.Errorf("second job_id = %v, want 202", jobs[1].(map[string]any)["job_id"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade]", calls)
 	}
 }

--- a/server/tools_app_test.go
+++ b/server/tools_app_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -322,5 +323,83 @@ func TestAppUpdateAll_SuccessReturnsJobIDs(t *testing.T) {
 	}
 	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade]" {
 		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade]", calls)
+	}
+}
+
+func TestAppUpdateAll_PartialSuccessReturnsStartedJobIDsAndFailures(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				return json.RawMessage(`[
+					{"name":"plex","upgrade_available":true},
+					{"name":"broken","upgrade_available":true},
+					{"name":"syncthing","upgrade_available":true}
+				]`), nil
+			case "app.upgrade":
+				if len(params) != 2 {
+					t.Fatalf("app.upgrade params = %v, want [name options]", params)
+				}
+				switch params[0] {
+				case "plex":
+					return json.RawMessage(`201`), nil
+				case "broken":
+					return nil, fmt.Errorf("upgrade unavailable")
+				case "syncthing":
+					return json.RawMessage(`202`), nil
+				default:
+					t.Fatalf("unexpected app.upgrade app %v", params[0])
+				}
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update_all", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	jobs := payload["jobs"].([]any)
+	if len(jobs) != 2 {
+		t.Fatalf("jobs len = %d, want 2", len(jobs))
+	}
+	if jobs[0].(map[string]any)["name"] != "plex" || jobs[0].(map[string]any)["job_id"] != float64(201) {
+		t.Errorf("first job = %v, want plex job 201", jobs[0])
+	}
+	if jobs[1].(map[string]any)["name"] != "syncthing" || jobs[1].(map[string]any)["job_id"] != float64(202) {
+		t.Errorf("second job = %v, want syncthing job 202", jobs[1])
+	}
+
+	summary := payload["summary"].(map[string]any)
+	if summary["jobs_started"] != float64(2) {
+		t.Errorf("jobs_started = %v, want 2", summary["jobs_started"])
+	}
+	if summary["failures"] != float64(1) {
+		t.Errorf("failures = %v, want 1", summary["failures"])
+	}
+
+	failures := payload["failures"].([]any)
+	if len(failures) != 1 {
+		t.Fatalf("failures len = %d, want 1", len(failures))
+	}
+	failure := failures[0].(map[string]any)
+	if failure["name"] != "broken" {
+		t.Errorf("failure name = %v, want broken", failure["name"])
+	}
+	errorText, ok := failure["error"].(string)
+	if !ok || !strings.Contains(errorText, "app.upgrade: upgrade unavailable") {
+		t.Errorf("failure error = %v, want app.upgrade context", failure["error"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade app.upgrade]", calls)
 	}
 }

--- a/yeti/tools.md
+++ b/yeti/tools.md
@@ -183,6 +183,17 @@ Restart an app.
   - `name` (string, required) — app name
 - API: `app.restart`
 
+### `truenas_app_update` **[write]**
+Upgrade an app to the latest available version and return the job ID.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.query` with filter `[["name", "=", name]]`, then `app.upgrade`
+
+### `truenas_app_update_all` **[write]**
+Upgrade all apps with updates available and return the job IDs.
+- Parameters: none
+- API: `app.query` with filter `[["upgrade_available", "=", true]]`, then `app.upgrade` for each app
+
 ## Job Tools (`tools_reports.go`)
 
 ### `truenas_jobs_list`


### PR DESCRIPTION
## Summary
- add write-gated `truenas_app_update` and `truenas_app_update_all` tools
- call `app.upgrade` with latest-version options and return job IDs for `truenas_jobs_list` tracking
- document the new write tools and cover read-only gating plus update behavior in tests

Closes #20

## Testing
- `make test`
- `make build`

## Safety
- [ ] This change does not introduce write-capable behavior.
- [x] This change introduces or modifies write-capable behavior and documents the opt-in safety model.
