### PR TITLE
feat(apps): add app update tools + domain docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,17 @@ After install, these commands are available in Claude Code:
 **update documentation** After any change to source code, update relevant documentation in CLAUDE.md, README.md and the yeti/ folder. A task is not complete without reviewing and updating relevant documentation.
 
 **yeti/ directory** The `yeti/` directory contains documentation written for AI consumption and context enhancement, not primarily for humans. Jobs like `doc-maintainer` and `issue-worker` instruct the AI to read `yeti/OVERVIEW.md` and related files for codebase context before performing tasks. Write content in this directory to be maximally useful to an AI agent understanding the codebase — detailed architecture, patterns, and decision rationale rather than user-facing guides.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`github.com/bketelsen/truenas-mcp`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-role vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo — `CONTEXT.md` at root + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,80 @@
+# truenas-mcp
+
+An MCP server that exposes TrueNAS SCALE management capabilities to AI assistants. It bridges the MCP protocol (spoken to AI clients over stdio) and the TrueNAS WebSocket JSON-RPC API (spoken to a NAS appliance).
+
+## Language
+
+### Infrastructure
+
+**Server**:
+The MCP server process — the binary that speaks MCP to AI clients. Not the NAS hardware.
+_Avoid_: host, daemon
+
+**Appliance**:
+The TrueNAS SCALE hardware or VM being managed. Identified by hostname or IP.
+_Avoid_: server, host, NAS, box
+
+**Tool**:
+An MCP-protocol callable exposed by the server. All tool names are prefixed `truenas_`. Tools are either read-only or mutating; mutating tools are only registered when the server is started with `--enable-writes`.
+_Avoid_: command, action, endpoint
+
+**Report**:
+A server-side aggregation tool that synthesizes data from multiple appliance queries into a single response. Unlike raw query tools, the server — not the appliance — does the assembly.
+_Avoid_: summary, dashboard
+
+### Storage
+
+**Pool**:
+A ZFS storage pool on the appliance — a collection of disks presenting a unified volume. TrueNAS term, rooted in ZFS.
+_Avoid_: volume, disk group
+
+**Dataset**:
+A ZFS filesystem or volume created within a Pool. Identified by its full path (e.g. `tank/media/movies`), which encodes the pool hierarchy.
+_Avoid_: share, folder, directory
+
+**Snapshot**:
+A point-in-time, read-only copy of a Dataset. Identified by dataset path and snapshot name.
+_Avoid_: backup, clone
+
+### Sharing
+
+**Share**:
+The umbrella concept for any network-exposed filesystem path on the appliance. Has two concrete subtypes: SMB Share and NFS Export.
+
+**SMB Share**:
+A Dataset mountpoint exposed over the SMB protocol. Has a name, path, and optional guest access flag.
+_Avoid_: Windows share, CIFS share
+
+**NFS Export**:
+A Dataset mountpoint exposed over the NFS protocol. Identified by path and configured network access rules.
+_Avoid_: NFS share, NFS mount
+
+### Apps
+
+**App**:
+A containerized workload installed and running on the appliance. Scoped to installed apps only — catalog entries that are not installed are out of scope.
+_Avoid_: container, service, pod
+
+### Operations
+
+**Alert**:
+A TrueNAS system notification with a level (INFO, WARNING, CRITICAL) and a dismissed state. Covers all notifications regardless of dismissed state. "Active alert" is informal shorthand for an undismissed one.
+_Avoid_: warning, notification, event
+
+**Job**:
+A TrueNAS-tracked asynchronous operation with a numeric ID and a lifecycle state (WAITING, RUNNING, SUCCESS, FAILED, ABORTED). Long-running operations (e.g. app updates) return a Job ID immediately. The AI client is responsible for polling status via `truenas_jobs_list` — the server does not wait or track job completion.
+_Avoid_: task, operation, process
+
+## Example dialogue
+
+> **Dev:** I want to update all apps that have pending updates.
+>
+> **Domain expert:** Call `truenas_app_update_all`. It returns a list of Job IDs — one per App being updated. Then poll `truenas_jobs_list` filtering by those IDs until each Job reaches SUCCESS or FAILED.
+>
+> **Dev:** What if I only want to update one App?
+>
+> **Domain expert:** Use `truenas_app_update` with the App name. Same pattern — you get back a single Job ID and poll from there.
+>
+> **Dev:** Can I check which Apps have updates before running it?
+>
+> **Domain expert:** Yes — `truenas_apps_update_report` is a Report that lists Apps with available updates. Read-only, no side effects, no Job IDs returned.

--- a/README.md
+++ b/README.md
@@ -118,4 +118,6 @@ Tools marked with `*` are excluded by default and are registered only with `--en
 | `truenas_app_start` | Start an app `*` |
 | `truenas_app_stop` | Stop an app `*` |
 | `truenas_app_restart` | Restart an app `*` |
+| `truenas_app_update` | Upgrade an app to the latest available version `*` |
+| `truenas_app_update_all` | Upgrade all apps with updates available `*` |
 | `truenas_jobs_list` | Recent TrueNAS jobs, optionally filtered by state or method |

--- a/docs/adr/0001-read-only-by-default.md
+++ b/docs/adr/0001-read-only-by-default.md
@@ -1,0 +1,5 @@
+# Read-only by default
+
+Mutating tools (create, delete, start, stop, restart, dismiss) are not registered unless the server is started with `--enable-writes` or `TRUENAS_ENABLE_WRITES=true`. An AI client connecting to a default server cannot see or invoke them.
+
+This fail-closed posture was chosen because first contact with a NAS appliance carries real risk — an AI client could delete datasets or stop apps before the operator has validated the tool responses. The cost of requiring an explicit opt-in is low; the cost of a destructive action on a production NAS is high. A read-only default makes the safe path the easy path.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── ...
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (…) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in skills | Label in our tracker | Meaning                                  |
+| --------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`  | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`    | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`  | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`  | Requires human implementation            |
+| `wontfix`       | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -62,6 +62,8 @@ func TestNew_ReadOnly_ToolListContainsNoWriteTools(t *testing.T) {
 		"truenas_app_start":       true,
 		"truenas_app_stop":        true,
 		"truenas_app_restart":     true,
+		"truenas_app_update":      true,
+		"truenas_app_update_all":  true,
 	}
 
 	for _, name := range listTools(t, mock, true) {

--- a/server/stdio_smoke_test.go
+++ b/server/stdio_smoke_test.go
@@ -69,6 +69,8 @@ func TestStdioSmoke_ReadOnlyToolList(t *testing.T) {
 		"truenas_app_start",
 		"truenas_app_stop",
 		"truenas_app_restart",
+		"truenas_app_update",
+		"truenas_app_update_all",
 	}
 	for _, name := range writeTools {
 		if tools[name] {

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -145,4 +145,105 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 		}
 		return jsonResult(result)
 	})
+
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_app_update",
+		Description: "Upgrade a named app to its latest available version and return the TrueNAS job ID.",
+		InputSchema: schema(map[string]any{
+			"name": stringProp("app name to upgrade"),
+		}, "name"),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		a := args(req)
+		name, ok := a["name"].(string)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("required parameter 'name' missing")
+		}
+
+		result, err := client.Call("app.query", [][]any{{"name", "=", name}})
+		if err != nil {
+			return nil, fmt.Errorf("app.query: %w", err)
+		}
+
+		var apps []map[string]any
+		if err := json.Unmarshal(result, &apps); err != nil {
+			return nil, fmt.Errorf("parsing app.query: %w", err)
+		}
+		if len(apps) == 0 {
+			return nil, fmt.Errorf("app %q not found", name)
+		}
+		upgradeAvailable, _ := apps[0]["upgrade_available"].(bool)
+		if !upgradeAvailable {
+			return nil, fmt.Errorf("app %q has no update available", name)
+		}
+
+		jobID, err := upgradeApp(client, name)
+		if err != nil {
+			return nil, err
+		}
+		return jsonValueResult(map[string]any{
+			"name":   name,
+			"job_id": jobID,
+		})
+	})
+
+	s.AddTool(&mcp.Tool{
+		Name:        "truenas_app_update_all",
+		Description: "Upgrade all apps with updates available and return the TrueNAS job IDs.",
+		InputSchema: noArgs(),
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		result, err := client.Call("app.query", [][]any{{"upgrade_available", "=", true}})
+		if err != nil {
+			return nil, fmt.Errorf("app.query: %w", err)
+		}
+
+		var apps []map[string]any
+		if err := json.Unmarshal(result, &apps); err != nil {
+			return nil, fmt.Errorf("parsing app.query: %w", err)
+		}
+
+		jobs := []map[string]any{}
+		for _, app := range apps {
+			upgradeAvailable, _ := app["upgrade_available"].(bool)
+			if !upgradeAvailable {
+				continue
+			}
+			name, ok := app["name"].(string)
+			if !ok || name == "" {
+				return nil, fmt.Errorf("app.query returned app without a name")
+			}
+			jobID, err := upgradeApp(client, name)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, map[string]any{
+				"name":   name,
+				"job_id": jobID,
+			})
+		}
+
+		return jsonValueResult(map[string]any{
+			"summary": map[string]any{
+				"updates_available": len(apps),
+				"jobs_started":      len(jobs),
+			},
+			"jobs": jobs,
+		})
+	})
+}
+
+func upgradeApp(client truenas.Caller, name string) (any, error) {
+	result, err := client.Call("app.upgrade", name, map[string]any{
+		"app_version":        "latest",
+		"values":             map[string]any{},
+		"snapshot_hostpaths": false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("app.upgrade: %w", err)
+	}
+
+	var jobID any
+	if err := json.Unmarshal(result, &jobID); err != nil {
+		return nil, fmt.Errorf("parsing app.upgrade: %w", err)
+	}
+	return jobID, nil
 }

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -202,6 +202,7 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 		}
 
 		jobs := []map[string]any{}
+		failures := []map[string]any{}
 		for _, app := range apps {
 			upgradeAvailable, _ := app["upgrade_available"].(bool)
 			if !upgradeAvailable {
@@ -209,11 +210,18 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			}
 			name, ok := app["name"].(string)
 			if !ok || name == "" {
-				return nil, fmt.Errorf("app.query returned app without a name")
+				failures = append(failures, map[string]any{
+					"error": "app.query returned app without a name",
+				})
+				continue
 			}
 			jobID, err := upgradeApp(client, name)
 			if err != nil {
-				return nil, err
+				failures = append(failures, map[string]any{
+					"name":  name,
+					"error": err.Error(),
+				})
+				continue
 			}
 			jobs = append(jobs, map[string]any{
 				"name":   name,
@@ -225,8 +233,10 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"summary": map[string]any{
 				"updates_available": len(apps),
 				"jobs_started":      len(jobs),
+				"failures":          len(failures),
 			},
-			"jobs": jobs,
+			"jobs":     jobs,
+			"failures": failures,
 		})
 	})
 }

--- a/server/tools_app_test.go
+++ b/server/tools_app_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -171,5 +172,155 @@ func TestAppRestart_MissingName(t *testing.T) {
 	result, err := callTool(t, mock, false, "truenas_app_restart", nil)
 	if err == nil && (result == nil || !result.IsError) {
 		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppUpdate_SuccessReturnsJobID(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				if len(params) != 1 {
+					t.Fatalf("app.query params = %v, want name filter", params)
+				}
+				filter, ok := params[0].([][]any)
+				if !ok {
+					t.Fatalf("app.query params[0] is %T, want [][]any", params[0])
+				}
+				if len(filter) != 1 || filter[0][0] != "name" || filter[0][1] != "=" || filter[0][2] != "plex" {
+					t.Fatalf("app.query filter = %v, want [[name = plex]]", filter)
+				}
+				return json.RawMessage(`[{"name":"plex","upgrade_available":true}]`), nil
+			case "app.upgrade":
+				if len(params) != 2 || params[0] != "plex" {
+					t.Fatalf("app.upgrade params = %v, want [plex options]", params)
+				}
+				options, ok := params[1].(map[string]any)
+				if !ok {
+					t.Fatalf("app.upgrade options is %T, want map[string]any", params[1])
+				}
+				if options["app_version"] != "latest" {
+					t.Fatalf("app_version = %v, want latest", options["app_version"])
+				}
+				return json.RawMessage(`123`), nil
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update", map[string]any{"name": "plex"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload["name"] != "plex" {
+		t.Errorf("name = %v, want plex", payload["name"])
+	}
+	if payload["job_id"] != float64(123) {
+		t.Errorf("job_id = %v, want 123", payload["job_id"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade]", calls)
+	}
+}
+
+func TestAppUpdate_NoUpdateAvailableReturnsError(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			if method != "app.query" {
+				t.Fatalf("method = %q, want app.query", method)
+			}
+			return json.RawMessage(`[{"name":"plex","upgrade_available":false}]`), nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update", map[string]any{"name": "plex"})
+	if err == nil && (result == nil || !result.IsError) {
+		t.Fatal("expected error for app with no update available")
+	}
+}
+
+func TestAppUpdate_MissingName(t *testing.T) {
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			t.Fatal("Call should not be invoked")
+			return nil, nil
+		},
+	}
+	result, err := callTool(t, mock, false, "truenas_app_update", nil)
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestAppUpdateAll_SuccessReturnsJobIDs(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				if len(params) != 1 {
+					t.Fatalf("app.query params = %v, want upgrade_available filter", params)
+				}
+				filter, ok := params[0].([][]any)
+				if !ok {
+					t.Fatalf("app.query params[0] is %T, want [][]any", params[0])
+				}
+				if len(filter) != 1 || filter[0][0] != "upgrade_available" || filter[0][1] != "=" || filter[0][2] != true {
+					t.Fatalf("app.query filter = %v, want [[upgrade_available = true]]", filter)
+				}
+				return json.RawMessage(`[
+					{"name":"plex","upgrade_available":true},
+					{"name":"syncthing","upgrade_available":true}
+				]`), nil
+			case "app.upgrade":
+				if len(params) != 2 {
+					t.Fatalf("app.upgrade params = %v, want [name options]", params)
+				}
+				switch params[0] {
+				case "plex":
+					return json.RawMessage(`201`), nil
+				case "syncthing":
+					return json.RawMessage(`202`), nil
+				default:
+					t.Fatalf("unexpected app.upgrade app %v", params[0])
+				}
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update_all", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	jobs := payload["jobs"].([]any)
+	if len(jobs) != 2 {
+		t.Fatalf("jobs len = %d, want 2", len(jobs))
+	}
+	if jobs[0].(map[string]any)["job_id"] != float64(201) {
+		t.Errorf("first job_id = %v, want 201", jobs[0].(map[string]any)["job_id"])
+	}
+	if jobs[1].(map[string]any)["job_id"] != float64(202) {
+		t.Errorf("second job_id = %v, want 202", jobs[1].(map[string]any)["job_id"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade]", calls)
 	}
 }

--- a/server/tools_app_test.go
+++ b/server/tools_app_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -322,5 +323,83 @@ func TestAppUpdateAll_SuccessReturnsJobIDs(t *testing.T) {
 	}
 	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade]" {
 		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade]", calls)
+	}
+}
+
+func TestAppUpdateAll_PartialSuccessReturnsStartedJobIDsAndFailures(t *testing.T) {
+	calls := []string{}
+	mock := &mockCaller{
+		CallFunc: func(method string, params ...interface{}) (json.RawMessage, error) {
+			calls = append(calls, method)
+			switch method {
+			case "app.query":
+				return json.RawMessage(`[
+					{"name":"plex","upgrade_available":true},
+					{"name":"broken","upgrade_available":true},
+					{"name":"syncthing","upgrade_available":true}
+				]`), nil
+			case "app.upgrade":
+				if len(params) != 2 {
+					t.Fatalf("app.upgrade params = %v, want [name options]", params)
+				}
+				switch params[0] {
+				case "plex":
+					return json.RawMessage(`201`), nil
+				case "broken":
+					return nil, fmt.Errorf("upgrade unavailable")
+				case "syncthing":
+					return json.RawMessage(`202`), nil
+				default:
+					t.Fatalf("unexpected app.upgrade app %v", params[0])
+				}
+			default:
+				t.Fatalf("unexpected method %q", method)
+			}
+			return nil, nil
+		},
+	}
+
+	result, err := callTool(t, mock, false, "truenas_app_update_all", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resultText(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	jobs := payload["jobs"].([]any)
+	if len(jobs) != 2 {
+		t.Fatalf("jobs len = %d, want 2", len(jobs))
+	}
+	if jobs[0].(map[string]any)["name"] != "plex" || jobs[0].(map[string]any)["job_id"] != float64(201) {
+		t.Errorf("first job = %v, want plex job 201", jobs[0])
+	}
+	if jobs[1].(map[string]any)["name"] != "syncthing" || jobs[1].(map[string]any)["job_id"] != float64(202) {
+		t.Errorf("second job = %v, want syncthing job 202", jobs[1])
+	}
+
+	summary := payload["summary"].(map[string]any)
+	if summary["jobs_started"] != float64(2) {
+		t.Errorf("jobs_started = %v, want 2", summary["jobs_started"])
+	}
+	if summary["failures"] != float64(1) {
+		t.Errorf("failures = %v, want 1", summary["failures"])
+	}
+
+	failures := payload["failures"].([]any)
+	if len(failures) != 1 {
+		t.Fatalf("failures len = %d, want 1", len(failures))
+	}
+	failure := failures[0].(map[string]any)
+	if failure["name"] != "broken" {
+		t.Errorf("failure name = %v, want broken", failure["name"])
+	}
+	errorText, ok := failure["error"].(string)
+	if !ok || !strings.Contains(errorText, "app.upgrade: upgrade unavailable") {
+		t.Errorf("failure error = %v, want app.upgrade context", failure["error"])
+	}
+	if fmt.Sprint(calls) != "[app.query app.upgrade app.upgrade app.upgrade]" {
+		t.Errorf("calls = %v, want [app.query app.upgrade app.upgrade app.upgrade]", calls)
 	}
 }

--- a/yeti/tools.md
+++ b/yeti/tools.md
@@ -183,6 +183,17 @@ Restart an app.
   - `name` (string, required) — app name
 - API: `app.restart`
 
+### `truenas_app_update` **[write]**
+Upgrade an app to the latest available version and return the job ID.
+- Parameters:
+  - `name` (string, required) — app name
+- API: `app.query` with filter `[["name", "=", name]]`, then `app.upgrade`
+
+### `truenas_app_update_all` **[write]**
+Upgrade all apps with updates available and return the job IDs.
+- Parameters: none
+- API: `app.query` with filter `[["upgrade_available", "=", true]]`, then `app.upgrade` for each app
+
 ## Job Tools (`tools_reports.go`)
 
 ### `truenas_jobs_list`


### PR DESCRIPTION
## Summary

Four commits:

### App update tools
- `truenas_app_update` — update a named app, returns TrueNAS job ID
- `truenas_app_update_all` — update all apps with pending updates, returns job IDs
- `truenas_apps_update_report` — read-only report of apps with available updates
- Handles partial successes in update-all (continues on individual failures)

### Agent skills configuration
- `docs/agents/issue-tracker.md` — GitHub Issues via `gh` CLI
- `docs/agents/triage-labels.md` — default five-role triage vocabulary
- `docs/agents/domain.md` — single-context layout
- `CLAUDE.md` — `## Agent skills` block added

### Domain glossary + ADR
- `CONTEXT.md` — canonical domain language: Server vs Appliance, Pool/Dataset/Snapshot, Share/SMB Share/NFS Export, App, Alert, Job, Report
- `docs/adr/0001-read-only-by-default.md` — records the fail-closed mutating-tool posture and rationale