### PR TITLE
refactor: replace args() pass-through with typed parameter accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .envrc
-/truenas-mcp
+/truenas-mcp.worktrees/

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -93,48 +93,6 @@ func TestArrayProp(t *testing.T) {
 	}
 }
 
-func TestArgs_Valid(t *testing.T) {
-	req := &mcp.CallToolRequest{}
-	req.Params = &mcp.CallToolParamsRaw{
-		Arguments: json.RawMessage(`{"name":"tank","size":42}`),
-	}
-
-	a := args(req)
-	if a["name"] != "tank" {
-		t.Errorf("name = %v, want tank", a["name"])
-	}
-	if a["size"] != 42.0 {
-		t.Errorf("size = %v, want 42", a["size"])
-	}
-}
-
-func TestArgs_NilArguments(t *testing.T) {
-	req := &mcp.CallToolRequest{}
-	req.Params = &mcp.CallToolParamsRaw{}
-	a := args(req)
-	if a == nil {
-		t.Fatal("args returned nil, want empty map")
-	}
-	if len(a) != 0 {
-		t.Errorf("args returned %d entries, want 0", len(a))
-	}
-}
-
-func TestArgs_MalformedJSON(t *testing.T) {
-	req := &mcp.CallToolRequest{}
-	req.Params = &mcp.CallToolParamsRaw{
-		Arguments: json.RawMessage(`{invalid`),
-	}
-
-	a := args(req)
-	if a == nil {
-		t.Fatal("args returned nil, want empty map")
-	}
-	if len(a) != 0 {
-		t.Errorf("args returned %d entries, want 0", len(a))
-	}
-}
-
 func TestJsonResult(t *testing.T) {
 	raw := json.RawMessage(`{"hostname":"nas","version":"24.04"}`)
 	result, err := jsonResult(raw)

--- a/server/params.go
+++ b/server/params.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func parseArgs(req *mcp.CallToolRequest) map[string]any {
+	var m map[string]any
+	if err := json.Unmarshal(req.Params.Arguments, &m); err != nil || m == nil {
+		return map[string]any{}
+	}
+	return m
+}
+
+func requireString(req *mcp.CallToolRequest, field string) (string, error) {
+	m := parseArgs(req)
+	v, ok := m[field].(string)
+	if !ok || v == "" {
+		return "", fmt.Errorf("required parameter %q missing", field)
+	}
+	return v, nil
+}
+
+func optionalString(req *mcp.CallToolRequest, field string) string {
+	m := parseArgs(req)
+	v, _ := m[field].(string)
+	return v
+}
+
+func requireFloat64(req *mcp.CallToolRequest, field string) (float64, error) {
+	m := parseArgs(req)
+	v, ok := m[field].(float64)
+	if !ok {
+		return 0, fmt.Errorf("required parameter %q missing", field)
+	}
+	return v, nil
+}
+
+func optionalFloat64(req *mcp.CallToolRequest, field string) (float64, bool) {
+	m := parseArgs(req)
+	v, ok := m[field].(float64)
+	return v, ok && v > 0
+}
+
+func optionalBool(req *mcp.CallToolRequest, field string) bool {
+	m := parseArgs(req)
+	v, _ := m[field].(bool)
+	return v
+}
+
+func optionalSlice(req *mcp.CallToolRequest, field string) []any {
+	m := parseArgs(req)
+	v, _ := m[field].([]any)
+	return v
+}

--- a/server/params_test.go
+++ b/server/params_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func makeReq(t *testing.T, fields map[string]any) *mcp.CallToolRequest {
+	t.Helper()
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: b,
+		},
+	}
+}
+
+func TestRequireString_present(t *testing.T) {
+	req := makeReq(t, map[string]any{"name": "myapp"})
+	got, err := requireString(req, "name")
+	if err != nil || got != "myapp" {
+		t.Fatalf("got %q, err %v", got, err)
+	}
+}
+
+func TestRequireString_missing(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	_, err := requireString(req, "name")
+	if err == nil {
+		t.Fatal("expected error for missing required param")
+	}
+}
+
+func TestRequireString_empty(t *testing.T) {
+	req := makeReq(t, map[string]any{"name": ""})
+	_, err := requireString(req, "name")
+	if err == nil {
+		t.Fatal("expected error for empty required param")
+	}
+}
+
+func TestOptionalString_present(t *testing.T) {
+	req := makeReq(t, map[string]any{"level": "WARNING"})
+	got := optionalString(req, "level")
+	if got != "WARNING" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestOptionalString_absent(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	got := optionalString(req, "level")
+	if got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestRequireFloat64_present(t *testing.T) {
+	req := makeReq(t, map[string]any{"id": float64(42)})
+	got, err := requireFloat64(req, "id")
+	if err != nil || got != 42 {
+		t.Fatalf("got %v, err %v", got, err)
+	}
+}
+
+func TestRequireFloat64_missing(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	_, err := requireFloat64(req, "id")
+	if err == nil {
+		t.Fatal("expected error for missing required float64 param")
+	}
+}
+
+func TestOptionalBool_true(t *testing.T) {
+	req := makeReq(t, map[string]any{"guest_ok": true})
+	if !optionalBool(req, "guest_ok") {
+		t.Fatal("expected true")
+	}
+}
+
+func TestOptionalBool_absent(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	if optionalBool(req, "guest_ok") {
+		t.Fatal("expected false")
+	}
+}
+
+func TestOptionalSlice_present(t *testing.T) {
+	req := makeReq(t, map[string]any{"hosts": []any{"10.0.0.1"}})
+	got := optionalSlice(req, "hosts")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 element, got %v", got)
+	}
+}
+
+func TestOptionalSlice_absent(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	got := optionalSlice(req, "hosts")
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestOptionalFloat64_present(t *testing.T) {
+	req := makeReq(t, map[string]any{"limit": float64(25)})
+	got, ok := optionalFloat64(req, "limit")
+	if !ok || got != 25 {
+		t.Fatalf("got %v, ok %v", got, ok)
+	}
+}
+
+func TestOptionalFloat64_absent(t *testing.T) {
+	req := makeReq(t, map[string]any{})
+	_, ok := optionalFloat64(req, "limit")
+	if ok {
+		t.Fatal("expected ok=false for absent field")
+	}
+}

--- a/server/tools_alert.go
+++ b/server/tools_alert.go
@@ -16,9 +16,8 @@ func registerAlertReadTools(s *mcp.Server, client truenas.Caller) {
 			"level": stringProp("filter by alert level: INFO, WARNING, CRITICAL, or empty for all"),
 		}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
 		params := []any{}
-		if level, ok := a["level"].(string); ok && level != "" {
+		if level := optionalString(req, "level"); level != "" {
 			params = append(params, [][]any{{"level", "=", level}})
 		}
 		result, err := client.Call("alert.list", params...)
@@ -38,10 +37,9 @@ func registerAlertWriteTools(s *mcp.Server, client truenas.Caller) {
 			"id": stringProp("alert ID to dismiss"),
 		}, "id"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		id, ok := a["id"].(string)
-		if !ok || id == "" {
-			return nil, fmt.Errorf("required parameter 'id' missing")
+		id, err := requireString(req, "id")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("alert.dismiss", id)
 		if err != nil {

--- a/server/tools_app.go
+++ b/server/tools_app.go
@@ -29,10 +29,9 @@ func registerAppReadTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("app name to inspect"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("app.query", [][]any{{"name", "=", name}})
 		if err != nil {
@@ -96,10 +95,9 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("app name to start"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("app.start", name)
 		if err != nil {
@@ -115,10 +113,9 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("app name to stop"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("app.stop", name)
 		if err != nil {
@@ -134,10 +131,9 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("app name to restart"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("app.restart", name)
 		if err != nil {
@@ -153,10 +149,9 @@ func registerAppWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("app name to upgrade"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 
 		result, err := client.Call("app.query", [][]any{{"name", "=", name}})

--- a/server/tools_dataset.go
+++ b/server/tools_dataset.go
@@ -16,9 +16,8 @@ func registerDatasetReadTools(s *mcp.Server, client truenas.Caller) {
 			"pool": stringProp("optional pool name to filter datasets"),
 		}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
 		params := []any{}
-		if pool, ok := a["pool"].(string); ok && pool != "" {
+		if pool := optionalString(req, "pool"); pool != "" {
 			params = append(params, [][]any{{"pool", "=", pool}})
 		}
 		result, err := client.Call("pool.dataset.query", params...)
@@ -35,10 +34,9 @@ func registerDatasetReadTools(s *mcp.Server, client truenas.Caller) {
 			"path": stringProp("full dataset path (e.g. tank/data)"),
 		}, "path"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		path, ok := a["path"].(string)
-		if !ok || path == "" {
-			return nil, fmt.Errorf("required parameter 'path' missing")
+		path, err := requireString(req, "path")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("pool.dataset.query", [][]any{{"id", "=", path}})
 		if err != nil {
@@ -59,16 +57,15 @@ func registerDatasetWriteTools(s *mcp.Server, client truenas.Caller) {
 			"compression": stringProp("compression algorithm (e.g. lz4, zstd, off)"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		params := map[string]any{"name": name}
-		if comments, ok := a["comments"].(string); ok && comments != "" {
+		if comments := optionalString(req, "comments"); comments != "" {
 			params["comments"] = comments
 		}
-		if compression, ok := a["compression"].(string); ok && compression != "" {
+		if compression := optionalString(req, "compression"); compression != "" {
 			params["compression"] = compression
 		}
 		result, err := client.Call("pool.dataset.create", params)
@@ -85,10 +82,9 @@ func registerDatasetWriteTools(s *mcp.Server, client truenas.Caller) {
 			"path": stringProp("full dataset path to delete (e.g. tank/olddata)"),
 		}, "path"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		path, ok := a["path"].(string)
-		if !ok || path == "" {
-			return nil, fmt.Errorf("required parameter 'path' missing")
+		path, err := requireString(req, "path")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("pool.dataset.delete", path)
 		if err != nil {

--- a/server/tools_pool.go
+++ b/server/tools_pool.go
@@ -28,10 +28,9 @@ func registerPoolTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("name of the pool to inspect"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("pool.query", [][]any{{"name", "=", name}})
 		if err != nil {

--- a/server/tools_reports.go
+++ b/server/tools_reports.go
@@ -127,16 +127,15 @@ func registerJobReadTools(s *mcp.Server, client truenas.Caller) {
 			"limit":  numberProp("maximum jobs to return, default 50"),
 		}),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
 		filters := [][]any{}
-		if state, ok := a["state"].(string); ok && state != "" {
+		if state := optionalString(req, "state"); state != "" {
 			filters = append(filters, []any{"state", "=", strings.ToUpper(state)})
 		}
-		if method, ok := a["method"].(string); ok && method != "" {
+		if method := optionalString(req, "method"); method != "" {
 			filters = append(filters, []any{"method", "=", method})
 		}
 		limit := 50
-		if rawLimit, ok := a["limit"].(float64); ok && rawLimit > 0 {
+		if rawLimit, ok := optionalFloat64(req, "limit"); ok {
 			limit = int(rawLimit)
 		}
 		if limit > 200 {

--- a/server/tools_share.go
+++ b/server/tools_share.go
@@ -46,20 +46,19 @@ func registerShareWriteTools(s *mcp.Server, client truenas.Caller) {
 			"guest_ok": boolProp("allow guest access (default false)"),
 		}, "name", "path"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
-		path, ok := a["path"].(string)
-		if !ok || path == "" {
-			return nil, fmt.Errorf("required parameter 'path' missing")
+		path, err := requireString(req, "path")
+		if err != nil {
+			return nil, err
 		}
 		params := map[string]any{"name": name, "path": path}
-		if comment, ok := a["comment"].(string); ok && comment != "" {
+		if comment := optionalString(req, "comment"); comment != "" {
 			params["comment"] = comment
 		}
-		if guestOK, ok := a["guest_ok"].(bool); ok && guestOK {
+		if optionalBool(req, "guest_ok") {
 			params["guestok"] = true
 		}
 		result, err := client.Call("sharing.smb.create", params)
@@ -76,10 +75,9 @@ func registerShareWriteTools(s *mcp.Server, client truenas.Caller) {
 			"id": numberProp("share ID to delete"),
 		}, "id"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		id, ok := a["id"].(float64)
-		if !ok {
-			return nil, fmt.Errorf("required parameter 'id' missing")
+		id, err := requireFloat64(req, "id")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("sharing.smb.delete", int(id))
 		if err != nil {
@@ -97,16 +95,15 @@ func registerShareWriteTools(s *mcp.Server, client truenas.Caller) {
 			"hosts":    arrayProp("allowed hosts"),
 		}, "path"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		path, ok := a["path"].(string)
-		if !ok || path == "" {
-			return nil, fmt.Errorf("required parameter 'path' missing")
+		path, err := requireString(req, "path")
+		if err != nil {
+			return nil, err
 		}
 		params := map[string]any{"path": path}
-		if networks, ok := a["networks"].([]any); ok && len(networks) > 0 {
+		if networks := optionalSlice(req, "networks"); len(networks) > 0 {
 			params["networks"] = networks
 		}
-		if hosts, ok := a["hosts"].([]any); ok && len(hosts) > 0 {
+		if hosts := optionalSlice(req, "hosts"); len(hosts) > 0 {
 			params["hosts"] = hosts
 		}
 		result, err := client.Call("sharing.nfs.create", params)
@@ -123,10 +120,9 @@ func registerShareWriteTools(s *mcp.Server, client truenas.Caller) {
 			"id": numberProp("export ID to delete"),
 		}, "id"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		id, ok := a["id"].(float64)
-		if !ok {
-			return nil, fmt.Errorf("required parameter 'id' missing")
+		id, err := requireFloat64(req, "id")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("sharing.nfs.delete", int(id))
 		if err != nil {

--- a/server/tools_snapshot.go
+++ b/server/tools_snapshot.go
@@ -17,10 +17,9 @@ func registerSnapshotReadTools(s *mcp.Server, client truenas.Caller) {
 			"dataset": stringProp("dataset path to list snapshots for"),
 		}, "dataset"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		dataset, ok := a["dataset"].(string)
-		if !ok || dataset == "" {
-			return nil, fmt.Errorf("required parameter 'dataset' missing")
+		dataset, err := requireString(req, "dataset")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("zfs.snapshot.query", [][]any{{"dataset", "=", dataset}})
 		if err != nil {
@@ -36,10 +35,9 @@ func registerSnapshotReadTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("full snapshot name (e.g. tank/data@snap1)"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("zfs.snapshot.query", [][]any{{"id", "=", name}})
 		if err != nil {
@@ -59,12 +57,11 @@ func registerSnapshotWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name":    stringProp("optional snapshot name (auto-generates if omitted)"),
 		}, "dataset"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		dataset, ok := a["dataset"].(string)
-		if !ok || dataset == "" {
-			return nil, fmt.Errorf("required parameter 'dataset' missing")
+		dataset, err := requireString(req, "dataset")
+		if err != nil {
+			return nil, err
 		}
-		snapName, _ := a["name"].(string)
+		snapName := optionalString(req, "name")
 		if snapName == "" {
 			snapName = "auto-" + time.Now().UTC().Format("20060102-150405")
 		}
@@ -86,10 +83,9 @@ func registerSnapshotWriteTools(s *mcp.Server, client truenas.Caller) {
 			"name": stringProp("full snapshot name to delete (e.g. tank/data@snap1)"),
 		}, "name"),
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		a := args(req)
-		name, ok := a["name"].(string)
-		if !ok || name == "" {
-			return nil, fmt.Errorf("required parameter 'name' missing")
+		name, err := requireString(req, "name")
+		if err != nil {
+			return nil, err
 		}
 		result, err := client.Call("zfs.snapshot.delete", name)
 		if err != nil {

--- a/server/tools_system.go
+++ b/server/tools_system.go
@@ -41,14 +41,6 @@ func arrayProp(desc string) map[string]any {
 	return map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": desc}
 }
 
-func args(req *mcp.CallToolRequest) map[string]any {
-	var m map[string]any
-	if err := json.Unmarshal(req.Params.Arguments, &m); err != nil || m == nil {
-		return map[string]any{}
-	}
-	return m
-}
-
 func jsonResult(raw json.RawMessage) (*mcp.CallToolResult, error) {
 	pretty, err := json.MarshalIndent(json.RawMessage(raw), "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `server/params.go` with typed accessor functions: `requireString`, `optionalString`, `requireFloat64`, `optionalFloat64`, `optionalBool`, `optionalSlice`
- Migrate all 7 tool handler files to use the new accessors, eliminating 15+ copy-pasted type-assertion blocks
- Delete the shallow `args()` pass-through from `tools_system.go` and its now-redundant unit tests

## Motivation

The old pattern scattered identical validation logic across every handler:
```go
a := args(req)
name, ok := a["name"].(string)
    return nil, fmt.Errorf("required parameter 'name' missing")
}
```

The new pattern is one line per param with a real seam to test against:
```go
name, err := requireString(req, "name")
if err != nil {
    return nil, err
}
```

## Test Plan
- [x] 13 new unit tests covering all typed accessors (required/optional, present/absent/empty)
- [x] All 89 tests passing (79 original + 13 new − 3 deleted args tests)
- [x] No `a := args(req)` call sites remaining in production code