### PR TITLE
docs(cmd): add godoc comments to NewRootCmd and NewServeCmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"truenas-mcp/version"
 )
 
+// NewRootCmd returns the root cobra command for truenas-mcp.
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "truenas-mcp",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,6 +16,7 @@ type serveConfig struct {
 	TLSInsecure  bool
 }
 
+// NewServeCmd returns the cobra command that runs the MCP server over stdio.
 func NewServeCmd() *cobra.Command {
 	cfg := &serveConfig{}
 


### PR DESCRIPTION
Closes #24

Adds one-line godoc comments to the two exported cobra command constructors, matching the rest of the codebase's documentation convention.

- cmd/root.go: NewRootCmd
- cmd/serve.go: NewServeCmd

Gate: `make all` + `make test` green locally.