### PR TITLE
refactor(server): deduplicate jsonResult and jsonValueResult helpers

### DIFF
--- a/server/tools_system.go
+++ b/server/tools_system.go
@@ -42,15 +42,7 @@ func arrayProp(desc string) map[string]any {
 }
 
 func jsonResult(raw json.RawMessage) (*mcp.CallToolResult, error) {
-	pretty, err := json.MarshalIndent(json.RawMessage(raw), "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("formatting result: %w", err)
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(pretty)},
-		},
-	}, nil
+	return jsonValueResult(json.RawMessage(raw))
 }
 
 func registerSystemTools(s *mcp.Server, client truenas.Caller) {


### PR DESCRIPTION
Closes #25

Removes the duplicated marshal-indent + MCP text-content construction between `server/tools_system.go` (`jsonResult`) and `server/tools_reports.go` (`jsonValueResult`). Took the wrapper approach: `jsonResult` now delegates to `jsonValueResult` while preserving both existing helper signatures and all caller logic.

Gate: `make all` + `make test` green locally.