### PR TITLE
test(server): share write-tool name list between server_test and stdio_smoke_test

### DIFF
--- a/server/mock_test.go
+++ b/server/mock_test.go
@@ -17,6 +17,23 @@ type mockCaller struct {
 
 var _ truenas.Caller = (*mockCaller)(nil)
 
+var writeToolNames = []string{
+	"truenas_dataset_create",
+	"truenas_dataset_delete",
+	"truenas_snapshot_create",
+	"truenas_snapshot_delete",
+	"truenas_smb_create",
+	"truenas_smb_delete",
+	"truenas_nfs_create",
+	"truenas_nfs_delete",
+	"truenas_alert_dismiss",
+	"truenas_app_start",
+	"truenas_app_stop",
+	"truenas_app_restart",
+	"truenas_app_update",
+	"truenas_app_update_all",
+}
+
 func (m *mockCaller) Call(method string, params ...interface{}) (json.RawMessage, error) {
 	return m.CallFunc(method, params...)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,21 +49,9 @@ func TestNew_ReadOnly_ToolListContainsNoWriteTools(t *testing.T) {
 		},
 	}
 
-	writeTools := map[string]bool{
-		"truenas_dataset_create":  true,
-		"truenas_dataset_delete":  true,
-		"truenas_snapshot_create": true,
-		"truenas_snapshot_delete": true,
-		"truenas_smb_create":      true,
-		"truenas_smb_delete":      true,
-		"truenas_nfs_create":      true,
-		"truenas_nfs_delete":      true,
-		"truenas_alert_dismiss":   true,
-		"truenas_app_start":       true,
-		"truenas_app_stop":        true,
-		"truenas_app_restart":     true,
-		"truenas_app_update":      true,
-		"truenas_app_update_all":  true,
+	writeTools := make(map[string]bool, len(writeToolNames))
+	for _, name := range writeToolNames {
+		writeTools[name] = true
 	}
 
 	for _, name := range listTools(t, mock, true) {

--- a/server/stdio_smoke_test.go
+++ b/server/stdio_smoke_test.go
@@ -56,23 +56,7 @@ func TestStdioSmoke_ReadOnlyToolList(t *testing.T) {
 		tools[tool.Name] = true
 	}
 
-	writeTools := []string{
-		"truenas_dataset_create",
-		"truenas_dataset_delete",
-		"truenas_snapshot_create",
-		"truenas_snapshot_delete",
-		"truenas_smb_create",
-		"truenas_smb_delete",
-		"truenas_nfs_create",
-		"truenas_nfs_delete",
-		"truenas_alert_dismiss",
-		"truenas_app_start",
-		"truenas_app_stop",
-		"truenas_app_restart",
-		"truenas_app_update",
-		"truenas_app_update_all",
-	}
-	for _, name := range writeTools {
+	for _, name := range writeToolNames {
 		if tools[name] {
 			t.Fatalf("read-only stdio server registered write tool %q", name)
 		}


### PR DESCRIPTION
Closes #26

Removes the duplicated write-tool name list between `server/server_test.go` and `server/stdio_smoke_test.go`. Took option 1: a shared test-only variable now lives in `server/mock_test.go`.

Gate: `make all` + `make test` green locally.